### PR TITLE
add MONGO_DATABASE env variable

### DIFF
--- a/src/server/db/index.js
+++ b/src/server/db/index.js
@@ -3,8 +3,8 @@ import { Mongo } from './mongo';
 import { Firebase } from './firebase';
 
 const DBFromEnv = () => {
-  if (process.env.MONGO_URI) {
-    return new Mongo({ url: process.env.MONGO_URI });
+  if (process.env.MONGO_URI && process.env.MONGO_DATABASE) {
+    return new Mongo({ url: process.env.MONGO_URI, dbname: process.env.MONGO_DATABASE });
   } else if (
     process.env.FIREBASE_APIKEY &&
     process.env.FIREBASE_AUTHDOMAIN &&

--- a/src/server/db/index.test.js
+++ b/src/server/db/index.test.js
@@ -2,9 +2,12 @@ import { DBFromEnv } from '.';
 
 test('MONGO_URI', () => {
   process.env.MONGO_URI = 'test';
+  process.env.MONGO_DATABASE = 'database';
   const db = DBFromEnv();
   expect(db.url).toBe('test');
+  expect(db.dbname).toBe('database');
   delete process.env.MONGO_URI;
+  delete process.env.MONGO_DATABASE;
 });
 
 test('FIREBASE_CONFIG', () => {

--- a/src/server/db/mongo.js
+++ b/src/server/db/mongo.js
@@ -66,7 +66,7 @@ export class Mongo {
 
     const col = this.db.collection(id);
     delete state._id;
-    await col.insert(state);
+    await col.insertOne(state);
 
     return;
   }


### PR DESCRIPTION
Fixed warning in MongoDB and switched .insert() to .insertOne()
Added process.env.MONGO_DATABASE to set the default database name for Mongo in DBFromEnv().

#### Checklist

* [ ] Use a separate branch in your local repo (not `master`).
* [ ] Test coverage is 100% (or you have a story for why it's ok).
