### PR TITLE
Prohibit second log event during Update

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -139,7 +139,9 @@ class _ClientImpl {
      * The middleware below takes care of all these cases while
      * managing the log object.
      */
+    /* eslint-disable no-unused-vars */
     const LogMiddleware = store => next => action => {
+      /* eslint-enable no-unused-vars */
       const result = next(action);
       const state = store.getState();
 
@@ -157,8 +159,11 @@ class _ClientImpl {
         }
 
         case Actions.UPDATE: {
-          const deltalog = action.deltalog || [];
-          this.log = [...this.log, ...deltalog];
+          // don't update the log for the player twice (done already when handling that MAKE_MOVE)
+          if (!action.payload || +action.payload.playerID !== +this.playerID) {
+            const deltalog = action.deltalog || [];
+            this.log = [...this.log, ...deltalog];
+          }
           break;
         }
 

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -139,9 +139,7 @@ class _ClientImpl {
      * The middleware below takes care of all these cases while
      * managing the log object.
      */
-    /* eslint-disable no-unused-vars */
     const LogMiddleware = store => next => action => {
-      /* eslint-enable no-unused-vars */
       const result = next(action);
       const state = store.getState();
 

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -159,11 +159,20 @@ class _ClientImpl {
         }
 
         case Actions.UPDATE: {
-          // don't update the log for the player twice (done already when handling that MAKE_MOVE)
-          if (!action.payload || +action.payload.playerID !== +this.playerID) {
-            const deltalog = action.deltalog || [];
-            this.log = [...this.log, ...deltalog];
+          let id = -1;
+          if (this.log.length > 0) {
+            id = this.log[this.log.length - 1]._stateID;
           }
+
+          let deltalog = action.deltalog || [];
+
+          // Filter out actions that are already present
+          // in the current log. This may occur when the
+          // client adds an entry to the log followed by
+          // the update from the master here.
+          deltalog = deltalog.filter(l => l._stateID > id);
+
+          this.log = [...this.log, ...deltalog];
           break;
         }
 

--- a/src/client/client.test.js
+++ b/src/client/client.test.js
@@ -335,6 +335,30 @@ describe('log handling', () => {
     expect(client.log).toEqual([...deltalog, ...deltalog]);
   });
 
+  test('update with payload', () => {
+    client = Client({
+      game: Game({
+        moves: {
+          A: () => ({}),
+        },
+      }),
+      playerID: 0,
+    });
+
+    const state = { restore: true };
+    const deltalog = ['0', '1'];
+    const action = update(state, deltalog);
+
+    action.payload = {};
+    client.store.dispatch(action);
+    action.payload.playerID = 0;
+    client.store.dispatch(action);
+    action.payload.playerID = 1;
+    client.store.dispatch(action);
+
+    expect(client.log).toEqual([...deltalog, ...deltalog]);
+  });
+
   test('sync', () => {
     const state = { restore: true };
     const log = ['0', '1'];

--- a/src/client/client.test.js
+++ b/src/client/client.test.js
@@ -319,44 +319,29 @@ describe('log handling', () => {
     client.moves.A();
 
     expect(client.log).toEqual([
-      { action: makeMove('A', [], '0') },
-      { action: makeMove('A', [], '0') },
+      { action: makeMove('A', [], '0'), _stateID: 0 },
+      { action: makeMove('A', [], '0'), _stateID: 1 },
     ]);
   });
 
   test('update', () => {
-    const state = { restore: true };
-    const deltalog = ['0', '1'];
+    const state = { restore: true, _stateID: 0 };
+    const deltalog = [
+      {
+        action: {},
+        _stateID: 0,
+      },
+      {
+        action: {},
+        _stateID: 1,
+      },
+    ];
     const action = update(state, deltalog);
 
     client.store.dispatch(action);
     client.store.dispatch(action);
 
-    expect(client.log).toEqual([...deltalog, ...deltalog]);
-  });
-
-  test('update with payload', () => {
-    client = Client({
-      game: Game({
-        moves: {
-          A: () => ({}),
-        },
-      }),
-      playerID: 0,
-    });
-
-    const state = { restore: true };
-    const deltalog = ['0', '1'];
-    const action = update(state, deltalog);
-
-    action.payload = {};
-    client.store.dispatch(action);
-    action.payload.playerID = 0;
-    client.store.dispatch(action);
-    action.payload.playerID = 1;
-    client.store.dispatch(action);
-
-    expect(client.log).toEqual([...deltalog, ...deltalog]);
+    expect(client.log).toEqual(deltalog);
   });
 
   test('sync', () => {

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -79,7 +79,7 @@ export function Flow({
     const { payload } = action;
     if (events.hasOwnProperty(payload.type)) {
       const context = { playerID: payload.playerID, dispatch };
-      const newLogEntry = { action };
+      const newLogEntry = { action, _stateID: state._stateID };
       const deltalog = [...(state.deltalog || []), newLogEntry];
       state = { ...state, deltalog };
       const args = [state].concat(payload.args);

--- a/src/core/reducer.js
+++ b/src/core/reducer.js
@@ -239,7 +239,7 @@ export function CreateGameReducer({ game, numPlayers, multiplayer }) {
 
         // don't call into events here
         const newState = apiCtx.updateAndDetach(
-          { ...state, deltalog: [{ action }] },
+          { ...state, deltalog: [{ action, _stateID: state._stateID }] },
           false
         );
         let ctx = newState.ctx;

--- a/src/core/reducer.test.js
+++ b/src/core/reducer.test.js
@@ -209,11 +209,11 @@ test('deltalog', () => {
   const actionC = gameEvent('endTurn');
 
   state = reducer(state, actionA);
-  expect(state.deltalog).toEqual([{ action: actionA }]);
+  expect(state.deltalog).toEqual([{ action: actionA, _stateID: 0 }]);
   state = reducer(state, actionB);
-  expect(state.deltalog).toEqual([{ action: actionB }]);
+  expect(state.deltalog).toEqual([{ action: actionB, _stateID: 1 }]);
   state = reducer(state, actionC);
-  expect(state.deltalog).toEqual([{ action: actionC }]);
+  expect(state.deltalog).toEqual([{ action: actionC, _stateID: 2 }]);
 });
 
 describe('Events API', () => {


### PR DESCRIPTION
This PR shall fix #302. The problem is that the log of the player that played the move is updated twice: Once for the MAKE_MOVE action, and a second time for the UPDATE action. The PR modifies this behaviour to NOT update the log inside UPDATE for the player that played the action.

Please have a special eye onto the update action. I'm pretty unsure whether this should have a payload at all since the action creator does not take it.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
