### PR TITLE
Allow result of onPhaseBegin to influence turn order

### DIFF
--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -376,7 +376,7 @@ export function FlowWithPhases({
   // Helper to perform start-of-phase initialization.
   const startPhase = function(state, config) {
     let G = config.onPhaseBegin(state.G, state.ctx);
-    let ctx = InitTurnOrderState(state.G, state.ctx, config.turnOrder);
+    let ctx = InitTurnOrderState(G, state.ctx, config.turnOrder);
 
     // Allow plugins to modify G and ctx at the beginning of a phase.
     G = plugins.G.onPhaseBegin(G, ctx, game);

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -69,11 +69,15 @@ describe('phases', () => {
           next: 'A',
         },
       },
+      turnOrder: {
+        first: G => (G.setupA ? '1' : '0'),
+      },
     });
 
     let state = { G: {}, ctx: flow.ctx(2) };
     state = flow.init(state);
     expect(state.G).toMatchObject({ setupA: true });
+    expect(state.ctx.currentPlayer).toBe('1');
     state = flow.processGameEvent(state, gameEvent('endPhase'));
     expect(state.G).toMatchObject({
       setupA: true,

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -69,21 +69,28 @@ describe('phases', () => {
           next: 'A',
         },
       },
+
       turnOrder: {
-        first: G => (G.setupA ? '1' : '0'),
+        first: G => {
+          if (G.setupB && !G.cleanupB) return '1';
+          return '0';
+        },
       },
     });
 
     let state = { G: {}, ctx: flow.ctx(2) };
     state = flow.init(state);
     expect(state.G).toMatchObject({ setupA: true });
-    expect(state.ctx.currentPlayer).toBe('1');
+    expect(state.ctx.currentPlayer).toBe('0');
+
     state = flow.processGameEvent(state, gameEvent('endPhase'));
     expect(state.G).toMatchObject({
       setupA: true,
       cleanupA: true,
       setupB: true,
     });
+    expect(state.ctx.currentPlayer).toBe('1');
+
     state = flow.processGameEvent(state, gameEvent('endPhase'));
     expect(state.G).toMatchObject({
       setupA: true,
@@ -91,6 +98,7 @@ describe('phases', () => {
       setupB: true,
       cleanupB: true,
     });
+    expect(state.ctx.currentPlayer).toBe('0');
   });
 
   test('endPhaseIf', () => {


### PR DESCRIPTION
#### Checklist

Fixes #339 by using returned G instead of state.G, added test handling.

* [X] Use a separate branch in your local repo (not `master`).
* [X] Test coverage is 100% (or you have a story for why it's ok).
