### PR TITLE
Add test case for modifying all players

### DIFF
--- a/src/plugins/plugin-player.js
+++ b/src/plugins/plugin-player.js
@@ -17,33 +17,36 @@ export default {
   fnWrap: moveFn => {
     return (G, ctx, ...args) => {
       const current = ctx.currentPlayer;
-      const player = G.players[current];
 
-      G = { ...G, player };
+      Object.defineProperty(G, 'player', {
+        get: () => {
+          console.log('getter');
+          return G.players[current];
+        },
 
-      let other = null;
-      let opponent = null;
+        set: function(value) {
+          console.log('setter');
+          this.players[current] = value;
+        },
+      });
+
       if (ctx.numPlayers == 2) {
-        other = current == '0' ? '1' : '0';
-        opponent = G.players[other];
-        G.opponent = opponent;
+        const other = current == '0' ? '1' : '0';
+
+        Object.defineProperty(G, 'opponent', {
+          get: () => G.players[other],
+          set: value => {
+            this.players[other] = value;
+          },
+        });
       }
 
       G = moveFn(G, ctx, ...args);
 
-      const players = {
-        ...G.players,
-        [current]: G.player,
-      };
-
-      if (other !== null) {
-        players[other] = G.opponent;
-      }
-
       {
         /* eslint-disable-next-line no-unused-vars */
         const { player, opponent, ...rest } = G;
-        return { ...rest, players };
+        return { ...rest };
       }
     };
   },

--- a/src/plugins/plugin-player.test.js
+++ b/src/plugins/plugin-player.test.js
@@ -82,7 +82,7 @@ describe('3 player game', () => {
     game = Game({
       moves: {
         A: G => {
-          G.player.field = 'A';
+          G.player = { field: 'A' };
           G.fields = Object.keys(G);
         },
         B: G => {

--- a/src/plugins/plugin-player.test.js
+++ b/src/plugins/plugin-player.test.js
@@ -85,6 +85,11 @@ describe('3 player game', () => {
           G.player.field = 'A';
           G.fields = Object.keys(G);
         },
+        B: G => {
+          Object.values(G.players).forEach(player => {
+            player.field = 'B';
+          });
+        },
       },
 
       plugins: [PluginPlayer],
@@ -101,6 +106,18 @@ describe('3 player game', () => {
         '0': { field: 'A' },
         '1': {},
         '2': {},
+      },
+      fields: ['players', 'player'],
+    });
+  });
+
+  test('Changing current player in G.players propagates the changes', () => {
+    state = reducer(state, makeMove('B'));
+    expect(state.G).toEqual({
+      players: {
+        '0': { field: 'B' },
+        '1': { field: 'B' },
+        '2': { field: 'B' },
       },
       fields: ['players', 'player'],
     });


### PR DESCRIPTION
Extend 3 player test case with a new move that changes a field for all players but iterating over the players object provided by the Players plugin.

This is currently a failing test, see #368 
