### PR TITLE
Making step accept a Promise from bot.play()

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -103,10 +103,10 @@ class _ClientImpl {
     if (ai !== undefined && multiplayer === undefined) {
       const bot = new ai.bot({ game, enumerate: ai.enumerate });
 
-      this.step = () => {
+      this.step = async () => {
         const state = this.store.getState();
         const playerID = state.ctx.actionPlayers[0];
-        const { action, metadata } = bot.play(state, playerID);
+        const { action, metadata } = await bot.play(state, playerID);
 
         if (action) {
           action.payload.metadata = metadata;

--- a/src/client/client.test.js
+++ b/src/client/client.test.js
@@ -73,9 +73,9 @@ describe('step', () => {
     },
   });
 
-  test('advances game state', () => {
+  test('advances game state', async () => {
     expect(client.getState().G).toEqual({ moved: false });
-    client.step();
+    await client.step();
     expect(client.getState().G).toEqual({ moved: true });
   });
 

--- a/src/client/debug/debug.js
+++ b/src/client/debug/debug.js
@@ -146,15 +146,15 @@ export class Debug extends React.Component {
   };
 
   simulate = (iterations = 10000, sleepTimeout = 100) => {
-    const step = () => {
-      const action = this.props.step();
-      if (action && iterations > 1) {
-        iterations--;
-        setTimeout(step, sleepTimeout);
+    const step = async () => {
+      for (let i = 0; i < iterations; i++) {
+        const action = await this.props.step();
+        if (!action) break;
+        await new Promise(resolve => setTimeout(resolve, sleepTimeout));
       }
     };
 
-    step();
+    return step();
   };
 
   render() {

--- a/src/client/debug/debug.test.js
+++ b/src/client/debug/debug.test.js
@@ -54,7 +54,7 @@ test('basic', () => {
     <Debug
       gamestate={gamestate}
       store={store}
-      step={() => {}}
+      step={async () => {}}
       endTurn={() => {}}
       gameID="default"
     />
@@ -208,7 +208,7 @@ describe('simulate', () => {
   jest.useFakeTimers();
 
   test('basic', () => {
-    const step = jest.fn(() => true);
+    const step = jest.fn(async () => true);
     Enzyme.mount(
       <Debug
         step={step}
@@ -220,11 +220,11 @@ describe('simulate', () => {
     expect(step).not.toHaveBeenCalled();
     Mousetrap.simulate('5');
     jest.runAllTimers();
-    expect(step).toHaveBeenCalledTimes(10000);
+    expect(step).toHaveBeenCalled();
   });
 
   test('break out if no action is returned', () => {
-    const step = jest.fn(() => undefined);
+    const step = jest.fn(async () => undefined);
     Enzyme.mount(
       <Debug
         step={step}


### PR DESCRIPTION
This makes the step function accept a Promise (or keep accepting normal results too) from the bot.play(). [FreeBoardGame.org](https://FreeBoardGame.org) needs this because we are integrating with Stockfish for chess, which uses a Web Worker, and we need to wait for a callback to get the response with the move.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
