### PR TITLE
Fix prop name in secret-state doc

### DIFF
--- a/docs/secret-state.md
+++ b/docs/secret-state.md
@@ -33,7 +33,7 @@ player in a game, use the `player` prop to make the client
 aware of this.
 
 ```
-ReactDOM.render(<App gameID="gameid" player="1" />, document.getElementById('root'));
+ReactDOM.render(<App gameID="gameid" playerID="1" />, document.getElementById('root'));
 ```
 
 From now on, this client will see state that is customized


### PR DESCRIPTION
The `player=1` prop didn't work for filtering `players` data in my environment. It worked by fixing it to `playerID`.

c.f. https://github.com/nicolodavis/boardgame.io/blob/fb19e9b9abe5adf5f82b5ca89eb7f66630686138/examples/react-web/src/secret-state/multiview.js#L27

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
  - just doc fix so I haven't check it