### PR TITLE
Auto-add trailing slash to server only if needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6846,13 +6846,6 @@
             "write-file-atomic": "^2.0.0",
             "xdg-basedir": "^3.0.0"
           }
-        },
-        "graceful-fs": {
-          "version": "4.1.15",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-          "dev": true,
-          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6846,6 +6846,13 @@
             "write-file-atomic": "^2.0.0",
             "xdg-basedir": "^3.0.0"
           }
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/client/transport/socketio.js
+++ b/src/client/transport/socketio.js
@@ -72,8 +72,11 @@ export class SocketIO {
         if (server.search(/^https?:\/\//) == -1) {
           server = 'http://' + this.server;
         }
-
-        this.socket = io(server + '/' + this.gameName, this.socketOpts);
+        if (server.substr(-1) != '/') {
+          // add trailing slash if not already present
+          server = server + '/';
+        }
+        this.socket = io(server + this.gameName, this.socketOpts);
       } else {
         this.socket = io('/' + this.gameName, this.socketOpts);
       }

--- a/src/client/transport/socketio.test.js
+++ b/src/client/transport/socketio.test.js
@@ -144,6 +144,13 @@ describe('server option', () => {
     expect(m.socket.io.engine.secure).toEqual(false);
   });
 
+  test('without trailing slash', () => {
+    const server = 'http://' + hostname + ':' + port;
+    const m = new SocketIO({ server });
+    m.connect();
+    expect(m.socket.io.uri).toEqual(server + '/default');
+  });
+
   test('https', () => {
     const serverWithProtocol = 'https://' + hostname + ':' + port + '/';
     const m = new SocketIO({ server: serverWithProtocol });


### PR DESCRIPTION
Auto-add trailing slash to server only if needed

I spent a ton of time trying to figure out why ```{ server: 'http://bgioserver/' }``` wasn't working -- I didn't realize that BGIO added the trailing slash for me.  Now BGIO will only add the trailing slash if it is necessary.

#### Checklist

* [X] Use a separate branch in your local repo (not `master`).
* [X] Test coverage is 100% (or you have a story for why it's ok).
