### PR TITLE
custom client transport should be a constructor (IMO)

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -273,7 +273,14 @@ class _ClientImpl {
           socketOpts,
         });
       } else if (multiplayer.transport !== undefined) {
-        this.transport = multiplayer.transport;
+        this.transport = new multiplayer.transport({
+          store: this.store,
+          gameID: gameID,
+          playerID: playerID,
+          gameName: game.name,
+          numPlayers,
+          socketOpts,
+        });
       } else {
         error('invalid multiplayer spec');
       }

--- a/src/client/client.test.js
+++ b/src/client/client.test.js
@@ -194,18 +194,22 @@ describe('multiplayer', () => {
   });
 
   describe('custom transport', () => {
-    const transport = { custom: true };
+    class CustomTransport {
+      custom = true;
+    }
+
     let client;
 
     beforeAll(() => {
       client = Client({
         game: Game({ moves: { A: () => {} } }),
-        multiplayer: { transport },
+        multiplayer: { transport: CustomTransport },
       });
     });
 
     test('correct transport used', () => {
-      expect(client.transport).toBe(transport);
+      expect(client.transport).toBeInstanceOf(CustomTransport);
+      expect(client.transport.custom).toBe(true);
     });
   });
 


### PR DESCRIPTION
Hi,

I'm implementing a custom transport. Having a parameter that just override transport is not very useful as the transport will need access to things like the store (same way that local and socketio transport do).

#### Checklist

* [V] Use a separate branch in your local repo (not `master`).
* [V] Test coverage is 100% (or you have a story for why it's ok).
