### PR TITLE
server api: fix test of argument 'playerID' 

### DIFF
--- a/src/server/api.js
+++ b/src/server/api.js
@@ -149,7 +149,7 @@ export const addApiToServer = ({ app, db, games, lobbyConfig }) => {
   router.post('/games/:name/:id/join', koaBody(), async ctx => {
     const playerID = ctx.request.body.playerID;
     const playerName = ctx.request.body.playerName;
-    if (!playerID) {
+    if (typeof playerID === 'undefined') {
       ctx.throw(403, 'playerID is required');
     }
     if (!playerName) {
@@ -186,10 +186,9 @@ export const addApiToServer = ({ app, db, games, lobbyConfig }) => {
     const credentials = ctx.request.body.credentials;
     const namespacedGameID = getNamespacedGameID(roomID, gameName);
     const gameMetadata = await db.get(GameMetadataKey(namespacedGameID));
-    if (!playerID) {
+    if (typeof playerID === 'undefined') {
       ctx.throw(403, 'playerID is required');
     }
-
     if (!gameMetadata) {
       ctx.throw(404, 'Game ' + roomID + ' not found');
     }


### PR DESCRIPTION
In the lobby example, playerID=0 was being considered 'undefined' in request 'leave', leading to error 403

#### Checklist

* [ ] Use a separate branch in your local repo (not `master`).
* [ ] Test coverage is 100% (or you have a story for why it's ok).
