### PR TITLE
Add search plugin to docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -42,6 +42,7 @@
     loadSidebar: true,
     subMaxLevel: 2,
     auto2top: true,
+    search: 'auto', // default
     markdown: {
       renderer: {
         code: function(code, lang) {
@@ -59,6 +60,7 @@
 </script>
 
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+<script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
 
 <script>
   ((window.gitter = {}).chat = {}).options = {


### PR DESCRIPTION
Adds text search plugin to docsify– closes #415.

![boardgame-io-docs-search](https://user-images.githubusercontent.com/5051745/60062924-efe95400-96af-11e9-98ad-f6640b0ef676.gif)
