### PR TITLE
TypeScript: Mimic Node.js module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
+    "moduleResolution": "node",
     "declaration": true,
     "outDir": "built-ts",
     "strict": false,


### PR DESCRIPTION
Mimic Node.js module resolution to avoid warnings when using relative imports.

![33A9152A-AE15-40BF-BA5D-8ED7C8AB1B13](https://user-images.githubusercontent.com/304383/61582044-c3c8c380-aaf3-11e9-930e-69655d37f720.jpeg)


#### Checklist

* [X] Use a separate branch in your local repo (not `master`).
* [X] Test coverage is 100% (or you have a story for why it's ok).
