### PR TITLE
Add tests to phases overhaul

### DIFF
--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -155,6 +155,20 @@ describe('phases', () => {
   });
 });
 
+describe('move counts', () => {
+  test('numMoves', () => {
+    const flow = Flow({});
+    let state = flow.init({ ctx: flow.ctx(2) });
+    expect(state.ctx.numMoves).toBe(0);
+    state = flow.processMove(state, makeMove().payload);
+    expect(state.ctx.numMoves).toBe(1);
+    state = flow.processMove(state, makeMove().payload);
+    expect(state.ctx.numMoves).toBe(2);
+    state = flow.processGameEvent(state, gameEvent('endTurn'));
+    expect(state.ctx.numMoves).toBe(0);
+  });
+});
+
 test('moveLimit', () => {
   {
     const flow = Flow({

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -167,6 +167,30 @@ describe('move counts', () => {
     state = flow.processGameEvent(state, gameEvent('endTurn'));
     expect(state.ctx.numMoves).toBe(0);
   });
+
+  test('currentPlayerMoves', () => {
+    const flow = Flow({});
+    let state = flow.init({ ctx: flow.ctx(2) });
+    console.log({ flow, state });
+    expect(state.ctx.currentPlayerMoves).toBe(0);
+    state = flow.processMove(
+      state,
+      makeMove(undefined, undefined, '0').payload
+    );
+    expect(state.ctx.currentPlayerMoves).toBe(1);
+    state = flow.processMove(
+      state,
+      makeMove(undefined, undefined, '0').payload
+    );
+    state = flow.processMove(
+      state,
+      makeMove(undefined, undefined, '1').payload
+    );
+    expect(state.ctx.currentPlayerMoves).toBe(2);
+    expect(state.ctx.numMoves).toBe(3);
+    state = flow.processGameEvent(state, gameEvent('endTurn'));
+    expect(state.ctx.currentPlayerMoves).toBe(0);
+  });
 });
 
 test('moveLimit', () => {

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -155,42 +155,17 @@ describe('phases', () => {
   });
 });
 
-describe('move counts', () => {
-  test('numMoves', () => {
-    const flow = Flow({});
-    let state = flow.init({ ctx: flow.ctx(2) });
-    expect(state.ctx.numMoves).toBe(0);
-    state = flow.processMove(state, makeMove().payload);
-    expect(state.ctx.numMoves).toBe(1);
-    state = flow.processMove(state, makeMove().payload);
-    expect(state.ctx.numMoves).toBe(2);
-    state = flow.processGameEvent(state, gameEvent('endTurn'));
-    expect(state.ctx.numMoves).toBe(0);
-  });
-
-  test('currentPlayerMoves', () => {
-    const flow = Flow({});
-    let state = flow.init({ ctx: flow.ctx(2) });
-    console.log({ flow, state });
-    expect(state.ctx.currentPlayerMoves).toBe(0);
-    state = flow.processMove(
-      state,
-      makeMove(undefined, undefined, '0').payload
-    );
-    expect(state.ctx.currentPlayerMoves).toBe(1);
-    state = flow.processMove(
-      state,
-      makeMove(undefined, undefined, '0').payload
-    );
-    state = flow.processMove(
-      state,
-      makeMove(undefined, undefined, '1').payload
-    );
-    expect(state.ctx.currentPlayerMoves).toBe(2);
-    expect(state.ctx.numMoves).toBe(3);
-    state = flow.processGameEvent(state, gameEvent('endTurn'));
-    expect(state.ctx.currentPlayerMoves).toBe(0);
-  });
+test('numMoves', () => {
+  const flow = Flow({});
+  let state = flow.init({ ctx: flow.ctx(2) });
+  expect(state.ctx.numMoves).toBe(0);
+  state = flow.processMove(state, makeMove(undefined, undefined, '0').payload);
+  expect(state.ctx.numMoves).toBe(1);
+  state = flow.processMove(state, makeMove(undefined, undefined, '0').payload);
+  state = flow.processMove(state, makeMove(undefined, undefined, '1').payload);
+  expect(state.ctx.numMoves).toBe(2);
+  state = flow.processGameEvent(state, gameEvent('endTurn'));
+  expect(state.ctx.numMoves).toBe(0);
 });
 
 test('moveLimit', () => {

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -511,6 +511,11 @@ describe('SetStage', () => {
       state = reducer(state, makeMove('discard', undefined, '2'));
       expect(state.ctx.stage).toEqual({ '0': '' });
     });
+
+    test('stages reset on new turn', () => {
+      reducer(state, gameEvent('endTurn', undefined, '0'));
+      expect(state.ctx.stage).toEqual({ '1': 'A' });
+    });
   });
 });
 

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -508,7 +508,7 @@ describe('SetStage', () => {
     });
 
     test('stages reset on new turn', () => {
-      reducer(state, gameEvent('endTurn', undefined, '0'));
+      state = reducer(state, gameEvent('endTurn', undefined, '0'));
       expect(state.ctx.stage).toEqual({ '1': 'A' });
     });
   });


### PR DESCRIPTION
This adds tests to the `phases-overhaul` branch. They either show a bug, or test for an API implementation that I think would be more logical than the current implementation (could be a bug, or could have been a conscious decision).


---


### `turn.stages` not applied on new turn

When initialising a phase/game, the `turn.stages` object is used to set up `ctx.stage` for all players. However, given that `stages` is a property of `turn`, one might expect `stages` to also be used to update `ctx.stage` when a turn starts, but this is not the current behaviour.

To test the behaviour I would expect, I have added a test to the “militia” suite, asserting that after `endTurn`, we would expect the `'A'` stage to pass to the next player (c41a84c).


### ~~`ctx.currentPlayerMoves` exposed but not set~~

~~This branch adds a `currentPlayerMoves` field to `ctx`, but this is never incremented.~~

~~https://github.com/nicolodavis/boardgame.io/blob/6644667ee708a38db03051bdd3e269a5b027dfec/src/core/flow.js#L770~~

~~I have added a failing test for the expected behaviour (ef3fa81) and also an equivalent (passing) test for `ctx.numMoves` (fbb76ea).~~


### `ctx.numMoves` counts moves from all players

As per discussion below, for `moveLimit` to work as expected, `ctx.numMoves` should only count the current player’s moves. I have added a failing test that expects that behaviour (448c351).

---


There are a few things I haven’t manage to isolate yet, but I’ll add tests as I figure them out.