### PR TITLE
Fix “once” and rename `stage` to `activePlayers`

### DIFF
--- a/examples/react-web/src/turnorder/simulator.js
+++ b/examples/react-web/src/turnorder/simulator.js
@@ -43,8 +43,8 @@ class Board extends React.Component {
     let current = false;
     let onClick = () => {};
 
-    if (this.props.ctx.stage) {
-      if (this.props.playerID in this.props.ctx.stage) {
+    if (this.props.ctx.activePlayers) {
+      if (this.props.playerID in this.props.ctx.activePlayers) {
         className += ' active';
         active = true;
       }

--- a/packages/core.js
+++ b/packages/core.js
@@ -7,7 +7,7 @@
  */
 
 import { INVALID_MOVE } from '../src/core/reducer.js';
-import { Pass, Stage, TurnOrder } from '../src/core/turn-order.js';
+import { Pass, ActivePlayers, TurnOrder } from '../src/core/turn-order.js';
 import { PlayerView } from '../src/core/player-view.js';
 
-export { Stage, TurnOrder, Pass, PlayerView, INVALID_MOVE };
+export { ActivePlayers, TurnOrder, Pass, PlayerView, INVALID_MOVE };

--- a/src/ai/bot.js
+++ b/src/ai/bot.js
@@ -25,8 +25,8 @@ export function Simulate({ game, bots, state, depth }) {
   let iter = 0;
   while (state.ctx.gameover === undefined && iter < depth) {
     let playerID = state.ctx.currentPlayer;
-    if (state.ctx.stage) {
-      playerID = Object.keys(state.ctx.stage)[0];
+    if (state.ctx.activePlayers) {
+      playerID = Object.keys(state.ctx.activePlayers)[0];
     }
 
     const bot = bots instanceof Bot ? bots : bots[playerID];
@@ -128,8 +128,8 @@ export class MCTSBot extends Bot {
     if (playerID !== undefined) {
       actions = this.enumerate(G, ctx, playerID);
       objectives = this.objectives(G, ctx, playerID);
-    } else if (ctx.stage) {
-      for (let playerID in ctx.stage) {
+    } else if (ctx.activePlayers) {
+      for (let playerID in ctx.activePlayers) {
         actions = actions.concat(this.enumerate(G, ctx, playerID));
         objectives = objectives.concat(this.objectives(G, ctx, playerID));
       }
@@ -218,8 +218,8 @@ export class MCTSBot extends Bot {
     ) {
       const { G, ctx } = state;
       let playerID = ctx.currentPlayer;
-      if (ctx.stage) {
-        playerID = Object.keys(ctx.stage)[0];
+      if (ctx.activePlayers) {
+        playerID = Object.keys(ctx.activePlayers)[0];
       }
       const moves = this.enumerate(G, ctx, playerID);
 

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -114,8 +114,8 @@ class _ClientImpl {
         const state = this.store.getState();
 
         let playerID = state.ctx.currentPlayer;
-        if (state.ctx.stage) {
-          playerID = Object.keys(state.ctx.stage)[0];
+        if (state.ctx.activePlayers) {
+          playerID = Object.keys(state.ctx.activePlayers)[0];
         }
 
         const { action, metadata } = await bot.play(state, playerID);

--- a/src/client/client.test.js
+++ b/src/client/client.test.js
@@ -310,7 +310,7 @@ describe('event dispatchers', () => {
   test('default', () => {
     const game = {};
     const client = Client({ game });
-    expect(Object.keys(client.events)).toEqual(['endTurn', 'setStage']);
+    expect(Object.keys(client.events)).toEqual(['endTurn', 'setActivePlayers']);
     expect(client.getState().ctx.turn).toBe(1);
     client.events.endTurn();
     expect(client.getState().ctx.turn).toBe(2);
@@ -328,7 +328,7 @@ describe('event dispatchers', () => {
       'endTurn',
       'endPhase',
       'endGame',
-      'setStage',
+      'setActivePlayers',
     ]);
     expect(client.getState().ctx.turn).toBe(1);
     client.events.endTurn();
@@ -340,7 +340,7 @@ describe('event dispatchers', () => {
       events: {
         endPhase: false,
         endTurn: false,
-        setStage: false,
+        setActivePlayers: false,
       },
     };
     const client = Client({ game });

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -678,8 +678,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
   function ProcessMove(state, action) {
     let conf = GetPhase(state.ctx);
 
-    let stage = state.ctx.stage;
-    let _stageOnce = state.ctx._stageOnce;
+    let { stage, _stageOnce, stageCompleted } = state.ctx;
     if (_stageOnce) {
       const playerID = action.playerID;
       stage = Object.keys(stage)
@@ -692,6 +691,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       if (Object.keys(stage).length == 0) {
         stage = null;
         _stageOnce = false;
+        stageCompleted = true;
       }
     }
 
@@ -705,6 +705,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       ctx: {
         ...state.ctx,
         stage,
+        stageCompleted,
         _stageOnce,
         numMoves,
       },

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -679,7 +679,8 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     let conf = GetPhase(state.ctx);
 
     let stage = state.ctx.stage;
-    if (state.ctx._stageOnce) {
+    let _stageOnce = state.ctx._stageOnce;
+    if (_stageOnce) {
       const playerID = action.playerID;
       stage = Object.keys(stage)
         .filter(id => id !== playerID)
@@ -690,6 +691,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
 
       if (Object.keys(stage).length == 0) {
         stage = null;
+        _stageOnce = false;
       }
     }
 
@@ -703,6 +705,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       ctx: {
         ...state.ctx,
         stage,
+        _stageOnce,
         numMoves,
       },
     };

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -416,7 +416,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
 
     // Initialize the turn order state.
     if (currentPlayer) {
-      ctx = { ...ctx, currentPlayer };
+      ctx = { ...ctx, currentPlayer, activePlayersDone: null };
       if (conf.turn.activePlayers) {
         ctx = SetActivePlayers(ctx, conf.turn.activePlayers);
       }

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -7,8 +7,8 @@
  */
 
 import {
-  SetStageEvent,
-  SetStage,
+  SetActivePlayersEvent,
+  SetActivePlayers,
   InitTurnOrderState,
   UpdateTurnOrderState,
   TurnOrder,
@@ -87,8 +87,8 @@ export function FlowInternal({
 
     canPlayerCallEvent: (_G, ctx, playerID) => {
       const isCurrentPlayer = ctx.currentPlayer == playerID;
-      if (ctx.stage) {
-        return isCurrentPlayer && ctx.currentPlayer in ctx.stage;
+      if (ctx.activePlayers) {
+        return isCurrentPlayer && ctx.currentPlayer in ctx.activePlayers;
       }
       return isCurrentPlayer;
     },
@@ -101,7 +101,7 @@ export function FlowInternal({
         return false;
       }
 
-      if (ctx.stage === null && ctx.currentPlayer !== playerID) {
+      if (ctx.activePlayers === null && ctx.currentPlayer !== playerID) {
         return false;
       }
 
@@ -109,8 +109,8 @@ export function FlowInternal({
     },
 
     canPlayerMakeAnyMove: (_G, ctx, playerID) => {
-      if (ctx.stage) {
-        return playerID in ctx.stage;
+      if (ctx.activePlayers) {
+        return playerID in ctx.activePlayers;
       }
       return ctx.currentPlayer === playerID;
     },
@@ -198,8 +198,8 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
   if (events === undefined) {
     events = {};
   }
-  if (events.setStage === undefined) {
-    events.setStage = true;
+  if (events.setActivePlayers === undefined) {
+    events.setActivePlayers = true;
   }
   if (events.endPhase === undefined && phases) {
     events.endPhase = true;
@@ -417,8 +417,8 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     // Initialize the turn order state.
     if (currentPlayer) {
       ctx = { ...ctx, currentPlayer };
-      if (conf.turn.setStage) {
-        ctx = SetStage(ctx, conf.turn.setStage);
+      if (conf.turn.activePlayers) {
+        ctx = SetActivePlayers(ctx, conf.turn.activePlayers);
       }
     } else {
       // This is only called at the beginning of the phase
@@ -611,8 +611,8 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       next.push({ fn: UpdateTurn, arg, currentPlayer: ctx.currentPlayer });
     }
 
-    // Reset currentPlayer and stages.
-    ctx = { ...ctx, currentPlayer: null, stage: null };
+    // Reset currentPlayer and activePlayers.
+    ctx = { ...ctx, currentPlayer: null, activePlayers: null };
 
     // Add log entry.
     const action = gameEvent('endTurn', arg);
@@ -635,7 +635,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
   /**
    * Retrieves the relevant move that can be played by playerID.
    *
-   * If ctx.stage is set (i.e. one or more players are in some stage),
+   * If ctx.activePlayers is set (i.e. one or more players are in some stage),
    * then it attempts to find the move inside the stages config for
    * that turn. If the stage for a player is '', then the player is
    * allowed to make a move (as determined by the phase config), but
@@ -652,10 +652,11 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
   function GetMove(ctx, name, playerID) {
     const conf = GetPhase(ctx);
     const stages = conf.turn.stages;
+    const { activePlayers } = ctx;
 
-    if (ctx.stage && stages[ctx.stage[playerID]]) {
+    if (activePlayers && stages[activePlayers[playerID]]) {
       // Check if moves are defined for the player's stage.
-      const stage = stages[ctx.stage[playerID]];
+      const stage = stages[activePlayers[playerID]];
       if (stage) {
         const moves = stage.moves;
         if (name in moves) {
@@ -678,20 +679,21 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
   function ProcessMove(state, action) {
     let conf = GetPhase(state.ctx);
 
-    let { stage, _stageOnce, stageCompleted } = state.ctx;
-    if (_stageOnce) {
+    let { activePlayers, _activePlayersOnce, activePlayersDone } = state.ctx;
+
+    if (_activePlayersOnce) {
       const playerID = action.playerID;
-      stage = Object.keys(stage)
+      activePlayers = Object.keys(activePlayers)
         .filter(id => id !== playerID)
         .reduce((obj, key) => {
-          obj[key] = stage[key];
+          obj[key] = activePlayers[key];
           return obj;
         }, {});
 
-      if (Object.keys(stage).length == 0) {
-        stage = null;
-        _stageOnce = false;
-        stageCompleted = true;
+      if (Object.keys(activePlayers).length == 0) {
+        activePlayers = null;
+        _activePlayersOnce = false;
+        activePlayersDone = true;
       }
     }
 
@@ -704,9 +706,9 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       ...state,
       ctx: {
         ...state.ctx,
-        stage,
-        stageCompleted,
-        _stageOnce,
+        activePlayers,
+        activePlayersDone,
+        _activePlayersOnce,
         numMoves,
       },
     };
@@ -753,7 +755,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     endTurn: EndTurnEvent,
     endPhase: EndPhaseEvent,
     endGame: EndGameEvent,
-    setStage: SetStageEvent,
+    setActivePlayers: SetActivePlayersEvent,
   };
 
   let enabledEvents = {};
@@ -766,8 +768,8 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
   if (events.endGame) {
     enabledEvents['endGame'] = true;
   }
-  if (events.setStage) {
-    enabledEvents['setStage'] = true;
+  if (events.setActivePlayers) {
+    enabledEvents['setActivePlayers'] = true;
   }
 
   return FlowInternal({
@@ -778,7 +780,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       playOrder: [...new Array(numPlayers)].map((d, i) => i + ''),
       playOrderPos: 0,
       phase: startingPhase,
-      stage: null,
+      activePlayers: null,
     }),
     init: state => {
       return ProcessEvents(state, [{ fn: StartGame }]);

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -437,17 +437,19 @@ test('canPlayerMakeAnyMove', () => {
   let flow = FlowInternal({});
   expect(flow.canPlayerMakeAnyMove({}, {}, playerID)).toBe(false);
 
-  expect(flow.canPlayerMakeAnyMove({}, { stage: { '1': '' } }, playerID)).toBe(
-    false
-  );
-  expect(flow.canPlayerMakeAnyMove({}, { stage: { '0': '' } }, playerID)).toBe(
-    true
-  );
+  expect(
+    flow.canPlayerMakeAnyMove({}, { activePlayers: { '1': '' } }, playerID)
+  ).toBe(false);
+  expect(
+    flow.canPlayerMakeAnyMove({}, { activePlayers: { '0': '' } }, playerID)
+  ).toBe(true);
 
   // no one can make a move
   flow = FlowInternal({ canPlayerMakeAnyMove: () => false });
   expect(flow.canPlayerMakeAnyMove({}, {}, playerID)).toBe(false);
-  expect(flow.canPlayerMakeAnyMove({}, { stage: null }, playerID)).toBe(false);
+  expect(flow.canPlayerMakeAnyMove({}, { activePlayers: null }, playerID)).toBe(
+    false
+  );
   expect(flow.canPlayerMakeAnyMove({}, {}, '5')).toBe(false);
 });
 
@@ -459,7 +461,7 @@ test('canPlayerCallEvent', () => {
   expect(
     flow.canPlayerCallEvent(
       {},
-      { currentPlayer: '0', stage: { '1': '' } },
+      { currentPlayer: '0', activePlayers: { '1': '' } },
       playerID
     )
   ).toBe(false);
@@ -662,12 +664,12 @@ describe('infinite loops', () => {
   });
 });
 
-describe('setStage', () => {
-  test('sets stages at each turn', () => {
+describe('activePlayers', () => {
+  test('sets activePlayers at each turn', () => {
     const game = {
       turn: {
         stages: { A: {}, B: {} },
-        setStage: {
+        activePlayers: {
           currentPlayer: 'A',
           others: 'B',
         },
@@ -677,7 +679,7 @@ describe('setStage', () => {
     const client = Client({ game, numPlayers: 3 });
 
     expect(client.getState().ctx.currentPlayer).toBe('0');
-    expect(client.getState().ctx.stage).toEqual({
+    expect(client.getState().ctx.activePlayers).toEqual({
       '0': 'A',
       '1': 'B',
       '2': 'B',
@@ -686,7 +688,7 @@ describe('setStage', () => {
     client.events.endTurn();
 
     expect(client.getState().ctx.currentPlayer).toBe('1');
-    expect(client.getState().ctx.stage).toEqual({
+    expect(client.getState().ctx.activePlayers).toEqual({
       '0': 'B',
       '1': 'A',
       '2': 'B',

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -694,4 +694,64 @@ describe('activePlayers', () => {
       '2': 'B',
     });
   });
+
+  test('activePlayersDone', () => {
+    const spec = {
+      numPlayers: 3,
+      multiplayer: { local: true },
+      game: {
+        moves: {
+          moveA: (G, ctx) => {
+            ctx.events.setActivePlayers({ all: '', once: true });
+          },
+          moveB: G => G,
+        },
+      },
+    };
+
+    const p0 = Client({ ...spec, playerID: '0' });
+    const p1 = Client({ ...spec, playerID: '1' });
+    const p2 = Client({ ...spec, playerID: '2' });
+
+    p0.connect();
+    p1.connect();
+    p2.connect();
+
+    expect(p0.getState().ctx.currentPlayer).toBe('0');
+
+    expect(p0.getState().ctx.activePlayersDone).toBe(null);
+    p0.moves.moveA();
+    expect(p0.getState().ctx.activePlayersDone).toBe(false);
+
+    expect(p0.getState().ctx.activePlayers).toEqual({
+      '0': '',
+      '1': '',
+      '2': '',
+    });
+
+    p0.moves.moveB();
+
+    expect(p0.getState().ctx.activePlayersDone).toBe(false);
+    expect(p0.getState().ctx.activePlayers).toEqual({
+      '1': '',
+      '2': '',
+    });
+
+    p1.moves.moveB();
+
+    expect(p0.getState().ctx.activePlayersDone).toBe(false);
+    expect(p0.getState().ctx.activePlayers).toEqual({
+      '2': '',
+    });
+
+    p2.moves.moveB();
+
+    expect(p0.getState().ctx.activePlayersDone).toBe(true);
+    expect(p0.getState().ctx.activePlayers).toEqual(null);
+
+    p0.events.endTurn();
+
+    expect(p0.getState().ctx.activePlayersDone).toBe(null);
+    expect(p0.getState().ctx.activePlayers).toEqual(null);
+  });
 });

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -30,32 +30,32 @@ export const Pass = (G, ctx) => {
 };
 
 /**
- * Event to change the stages of different players in the current turn.
+ * Event to change the active players (and their stages) in the current turn.
  * @param {*} state
  * @param {*} arg
  */
-export function SetStageEvent(state, arg) {
-  return { ...state, ctx: SetStage(state.ctx, arg) };
+export function SetActivePlayersEvent(state, arg) {
+  return { ...state, ctx: SetActivePlayers(state.ctx, arg) };
 }
 
-export function SetStage(ctx, arg) {
-  let stage = ctx.stage || {};
-  let stageCompleted = null;
-  let _stageOnce = false;
+export function SetActivePlayers(ctx, arg) {
+  let activePlayers = ctx.activePlayers || {};
+  let activePlayersDone = null;
+  let _activePlayersOnce = false;
 
   if (arg.value) {
-    stage = arg.value;
+    activePlayers = arg.value;
   }
 
   if (arg.currentPlayer !== undefined) {
-    stage[ctx.currentPlayer] = arg.currentPlayer;
+    activePlayers[ctx.currentPlayer] = arg.currentPlayer;
   }
 
   if (arg.others !== undefined) {
     for (let i = 0; i < ctx.playOrder.length; i++) {
       const playerID = ctx.playOrder[i];
       if (playerID !== ctx.currentPlayer) {
-        stage[playerID] = arg.others;
+        activePlayers[playerID] = arg.others;
       }
     }
   }
@@ -63,23 +63,28 @@ export function SetStage(ctx, arg) {
   if (arg.all !== undefined) {
     for (let i = 0; i < ctx.playOrder.length; i++) {
       const playerID = ctx.playOrder[i];
-      stage[playerID] = arg.all;
+      activePlayers[playerID] = arg.all;
     }
   }
 
   if (arg.once) {
-    _stageOnce = true;
+    _activePlayersOnce = true;
   }
 
-  if (Object.keys(stage).length == 0) {
-    stage = null;
+  if (Object.keys(activePlayers).length == 0) {
+    activePlayers = null;
   }
 
-  if (arg.once && Object.keys(stage).length > 0) {
-    stageCompleted = false;
+  if (arg.once && Object.keys(activePlayers).length > 0) {
+    activePlayersDone = false;
   }
 
-  return { ...ctx, stage, stageCompleted, _stageOnce };
+  return {
+    ...ctx,
+    activePlayers,
+    activePlayersDone,
+    _activePlayersOnce,
+  };
 }
 
 /**
@@ -115,7 +120,7 @@ export function InitTurnOrderState(G, ctx, turn) {
   const currentPlayer = getCurrentPlayer(playOrder, playOrderPos);
 
   ctx = { ...ctx, currentPlayer, playOrderPos, playOrder };
-  ctx = SetStage(ctx, turn.setStage || {});
+  ctx = SetActivePlayers(ctx, turn.activePlayers || {});
 
   return ctx;
 }
@@ -250,7 +255,7 @@ export const TurnOrder = {
   },
 };
 
-export const Stage = {
+export const ActivePlayers = {
   /**
    * ANY
    *

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -40,6 +40,7 @@ export function SetStageEvent(state, arg) {
 
 export function SetStage(ctx, arg) {
   let stage = ctx.stage || {};
+  let stageCompleted = null;
   let _stageOnce = false;
 
   if (arg.value) {
@@ -74,7 +75,11 @@ export function SetStage(ctx, arg) {
     stage = null;
   }
 
-  return { ...ctx, stage, _stageOnce };
+  if (arg.once && Object.keys(stage).length > 0) {
+    stageCompleted = false;
+  }
+
+  return { ...ctx, stage, stageCompleted, _stageOnce };
 }
 
 /**

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -257,21 +257,21 @@ export const TurnOrder = {
 
 export const ActivePlayers = {
   /**
-   * ANY
+   * ALL
    *
    * The turn stays with one player, but any player can play (in any order)
    * until the phase ends.
    */
-  ANY: { all: '' },
+  ALL: { all: '' },
 
   /**
-   * ANY_ONCE
+   * ALL_ONCE
    *
    * The turn stays with one player, but any player can play (once, and in any order).
    * This is typically used in a phase where you want to elicit a response
    * from every player in the game.
    */
-  ANY_ONCE: { all: '', once: true },
+  ALL_ONCE: { all: '', once: true },
 
   /**
    * OTHERS

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -122,6 +122,8 @@ describe('turn orders', () => {
 
     expect(state.ctx.currentPlayer).toBe('1');
     expect(state.ctx.stage).toBeNull();
+
+    state = flow.processMove(state, makeMove('', null, '1').payload);
   });
 
   test('OTHERS', () => {

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -369,6 +369,7 @@ describe('SetStage', () => {
       gameEvent('setStage', [{ all: '' }])
     );
     expect(newState.ctx.stage).toMatchObject({ '0': '', '1': '' });
+    expect(newState.ctx.stageCompleted).toBeNull();
   });
 
   test('once', () => {
@@ -387,10 +388,13 @@ describe('SetStage', () => {
     let state = InitializeGame({ game });
     state = reducer(state, makeMove('B', null, '0'));
     expect(Object.keys(state.ctx.stage)).toEqual(['0', '1']);
+    expect(state.ctx.stageCompleted).toBe(false);
     state = reducer(state, makeMove('A', null, '0'));
     expect(Object.keys(state.ctx.stage)).toEqual(['1']);
+    expect(state.ctx.stageCompleted).toBe(false);
     state = reducer(state, makeMove('A', null, '1'));
     expect(state.ctx.stage).toBeNull();
+    expect(state.ctx.stageCompleted).toBe(true);
   });
 
   test('others', () => {

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -172,6 +172,8 @@ describe('turn orders', () => {
 
     expect(state.ctx.currentPlayer).toBe('1');
     expect(state.ctx.stage).toBeNull();
+
+    state = flow.processMove(state, makeMove('', null, '1').payload);
   });
 
   test('CUSTOM', () => {

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -294,7 +294,7 @@ test('end game after everyone passes', () => {
 
   expect(Object.keys(state.ctx.activePlayers)).toEqual(['0', '1', '2']);
 
-  // Passes can be make in any order with TurnOrder.ANY.
+  // Passes can be made in any order with ActivePlayers.ALL.
 
   state = reducer(state, makeMove('pass', null, '1'));
   expect(state.ctx.gameover).toBe(undefined);

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -82,9 +82,9 @@ describe('turn orders', () => {
     expect(state.ctx.phase).toBe('B');
   });
 
-  test('ANY', () => {
+  test('ALL', () => {
     const flow = Flow({
-      turn: { activePlayers: ActivePlayers.ANY },
+      turn: { activePlayers: ActivePlayers.ALL },
     });
 
     let state = { ctx: flow.ctx(2) };
@@ -98,10 +98,10 @@ describe('turn orders', () => {
     expect(state.ctx.activePlayers).toEqual({ '0': '', '1': '' });
   });
 
-  test('ANY_ONCE', () => {
+  test('ALL_ONCE', () => {
     const flow = Flow({
       phases: {
-        A: { start: true, turn: { activePlayers: ActivePlayers.ANY_ONCE } },
+        A: { start: true, turn: { activePlayers: ActivePlayers.ALL_ONCE } },
       },
     });
 
@@ -285,7 +285,7 @@ test('passing', () => {
 test('end game after everyone passes', () => {
   const game = {
     endIf: G => G.allPassed,
-    turn: { activePlayers: ActivePlayers.ANY },
+    turn: { activePlayers: ActivePlayers.ALL },
     moves: { pass: Pass },
   };
 

--- a/src/master/master.js
+++ b/src/master/master.js
@@ -165,7 +165,10 @@ export class Master {
     // that can make moves right now and the person doing the
     // action is that player.
     if (action.type == UNDO || action.type == REDO) {
-      if (state.ctx.currentPlayer !== playerID || state.ctx.stage !== null) {
+      if (
+        state.ctx.currentPlayer !== playerID ||
+        state.ctx.activePlayers !== null
+      ) {
         logging.error(`playerID=[${playerID}] cannot undo / redo right now`);
         return;
       }


### PR DESCRIPTION
`ANY_ONCE` and `OTHERS_ONCE` no longer end the phase as before. I needed an `endIf` function to achieve that:

```js
phase: {
  turn: {
    setStage: Stage.ANY_ONCE
  },
  endIf: (G, ctx) => ctx.numMoves && ctx.stage === null,
}
```

First, a bug:

Once `stage` is empty, it is set to `null`. For example, with `ANY_ONCE` as moves are made:

```js 
stage: { 0: '', 1: '' } // no moves made
stage: { 0: '' }        // player 1 moved
stage: null             // player 0 moved
```

Because the `once` setting doesn’t end the phase as before, the current player can still make a move (control of moves returns from the stage to the phase/turn). A move triggers `processMove`, but `processMove` currently tries to fetch keys from the `ctx.stage` object when `ctx._stageOnce` is `true`, so when it encounters `null` a `TypeError` is thrown.

https://github.com/nicolodavis/boardgame.io/blob/1f6b1a24dba9a03c13d9509b80b8aec0968bea51/src/core/flow.js#L682-L684

I’ve added a step to the `ANY_ONCE` and `OTHERS_ONCE` turn order tests demonstrating this error.

The `TypeError` could be avoided easily by checking that `stage` isn’t `null` before using it, but the real error is that a move is even possible at this point.

There seem to be two options:

1. Instead of `null`, set `stage` to a constant when all players have played. So, by default `stage: null`, which indicates stage has not been set and move control stays with phase/turn, but `stage: 'STAGE_DONE'` to indicate all players have played, and keeps move control with the stage.
    
    A user could then do `endIf: (G, ctx) => ctx.stage === STAGE_DONE` in a turn or phase as desired.

2. (I think I prefer this one.) Ensure the `once` setting actually ends a turn or phase or… progresses to a different stage setting… The problem I guess is that before these were all properties of phases, so `once` would always end the phase. Now, any of the following could be desirable once all players have played during the stage:
    
    - end the turn
    - end the phase
    - set the stage to a new configuration

Option 1 leaves the developer in charge of deciding what happens once everyone has played and just makes sure no more moves are possible at that point.

Option 2 is more opinionated and might also need some new API to allow a developer to say what they want `once` to end/set.

Any thoughts?