### PR TITLE
Update examples for phases overhaul

### DIFF
--- a/examples/react-web/src/phases/diagram.js
+++ b/examples/react-web/src/phases/diagram.js
@@ -12,10 +12,8 @@ import { Client } from 'boardgame.io/react';
 import './diagram.css';
 
 const game = {
-  moves: {},
-  startingPhase: 'A',
   phases: {
-    A: { next: 'B' },
+    A: { start: true, next: 'B' },
     B: { next: 'C' },
     C: { next: 'A' },
   },

--- a/examples/react-web/src/turnorder/example-all-once.js
+++ b/examples/react-web/src/turnorder/example-all-once.js
@@ -7,12 +7,16 @@
  */
 
 import React from 'react';
-import { TurnOrder } from 'boardgame.io/core';
+import { ActivePlayers } from 'boardgame.io/core';
 
 const code = `{
-  startingPhase: 'A',
   phases: {
-    A: { turn: { order: TurnOrder.ANY_ONCE }, next: 'B' },
+    A: {
+      start: true,
+      next: 'B',
+      turn: { activePlayers: ActivePlayers.ALL_ONCE },
+      endIf: (G, ctx) => ctx.activePlayersDone,
+    },
     B: {},
   }
 }
@@ -31,12 +35,18 @@ export default {
       move: G => G,
     },
 
-    endTurn: false,
-    endPhase: false,
-    startingPhase: 'A',
+    events: {
+      endTurn: false,
+      endPhase: false,
+    },
 
     phases: {
-      A: { turn: { order: TurnOrder.ANY_ONCE }, next: 'B' },
+      A: {
+        start: true,
+        next: 'B',
+        turn: { activePlayers: ActivePlayers.ALL_ONCE },
+        endIf: (G, ctx) => ctx.activePlayersDone,
+      },
       B: {},
     },
   },

--- a/examples/react-web/src/turnorder/example-all.js
+++ b/examples/react-web/src/turnorder/example-all.js
@@ -7,10 +7,10 @@
  */
 
 import React from 'react';
-import { TurnOrder } from 'boardgame.io/core';
+import { ActivePlayers } from 'boardgame.io/core';
 
 const code = `{
-  turn: { order: TurnOrder.ANY },
+  turn: { activePlayers: ActivePlayers.ALL },
 }
 `;
 
@@ -27,8 +27,11 @@ export default {
       move: G => G,
     },
 
-    endTurn: false,
-    endPhase: false,
-    turn: { order: TurnOrder.ANY },
+    events: {
+      endTurn: false,
+      endPhase: false,
+    },
+
+    turn: { activePlayers: ActivePlayers.ALL },
   },
 };

--- a/examples/react-web/src/turnorder/example-custom-from.js
+++ b/examples/react-web/src/turnorder/example-custom-from.js
@@ -31,7 +31,10 @@ export default {
       order: ['1', '0', '2', '3', '5', '4'],
     }),
 
-    endPhase: false,
+    events: {
+      endPhase: false,
+    },
+
     turn: { order: TurnOrder.CUSTOM_FROM('order') },
   },
 };

--- a/examples/react-web/src/turnorder/example-custom.js
+++ b/examples/react-web/src/turnorder/example-custom.js
@@ -23,7 +23,9 @@ const Description = () => (
 export default {
   description: Description,
   game: {
-    endPhase: false,
+    events: {
+      endPhase: false,
+    },
     turn: { order: TurnOrder.CUSTOM(['1', '0', '2', '3', '5', '4']) },
   },
 };

--- a/examples/react-web/src/turnorder/example-once.js
+++ b/examples/react-web/src/turnorder/example-once.js
@@ -11,7 +11,11 @@ import { TurnOrder } from 'boardgame.io/core';
 
 const code = `{
   phases: {
-    A: { turn: { order: TurnOrder.ONCE }, next: 'B' },
+    A: {
+      start: true,
+      next: 'B',
+      turn: { order: TurnOrder.ONCE },
+    },
     B: {},
   },
 }
@@ -26,10 +30,15 @@ const Description = () => (
 export default {
   description: Description,
   game: {
-    endPhase: false,
-    startingPhase: 'A',
+    events: {
+      endPhase: false,
+    },
     phases: {
-      A: { turn: { order: TurnOrder.ONCE }, next: 'B' },
+      A: {
+        start: true,
+        next: 'B',
+        turn: { order: TurnOrder.ONCE },
+      },
       B: {},
     },
   },

--- a/examples/react-web/src/turnorder/example-others-once.js
+++ b/examples/react-web/src/turnorder/example-others-once.js
@@ -7,27 +7,24 @@
  */
 
 import React from 'react';
-import { TurnOrder } from 'boardgame.io/core';
 
 const code = `{
-  startingPhase: 'play',
-
-  phases: {
-    play: {},
-
-    discard: {
-      turn: { order: TurnOrder.OTHERS_ONCE },
+  moves: {
+    play(G, ctx) {
+      ctx.events.setActivePlayers({ others: 'discard', once: true });
+      return G;
     },
   },
 
-  moves: {
-    play(G, ctx) {
-      ctx.events.endPhase({ next: 'discard' });
-      return G;
-    },
-
-    discard(G) {
-      return G;
+  turn: {
+    stages: {
+      discard: {
+        moves: {
+          discard(G) {
+            return G;
+          },
+        },
+      },
     },
   },
 }
@@ -43,25 +40,26 @@ export default {
   description: Description,
 
   game: {
-    endPhase: false,
-    startingPhase: 'play',
-
-    phases: {
-      play: {},
-
-      discard: {
-        turn: { order: TurnOrder.OTHERS_ONCE },
-      },
+    events: {
+      endPhase: false,
     },
 
     moves: {
       play(G, ctx) {
-        ctx.events.endPhase({ next: 'discard' });
+        ctx.events.setActivePlayers({ others: 'discard', once: true });
         return G;
       },
+    },
 
-      discard(G) {
-        return G;
+    turn: {
+      stages: {
+        discard: {
+          moves: {
+            discard(G) {
+              return G;
+            },
+          },
+        },
       },
     },
   },

--- a/examples/react-web/src/turnorder/example-others.js
+++ b/examples/react-web/src/turnorder/example-others.js
@@ -7,10 +7,10 @@
  */
 
 import React from 'react';
-import { TurnOrder } from 'boardgame.io/core';
+import { ActivePlayers } from 'boardgame.io/core';
 
 const code = `{
-  turn: { order: TurnOrder.OTHERS },
+  turn: { activePlayers: ActivePlayers.OTHERS },
 }
 `;
 
@@ -27,7 +27,10 @@ export default {
       move: G => G,
     },
 
-    endPhase: false,
-    turn: { order: TurnOrder.OTHERS },
+    events: {
+      endPhase: false,
+    },
+
+    turn: { activePlayers: ActivePlayers.OTHERS },
   },
 };

--- a/examples/react-web/src/turnorder/simulator.css
+++ b/examples/react-web/src/turnorder/simulator.css
@@ -58,9 +58,18 @@
   border-bottom-color: #555;
 }
 
+#turnorder .stage-label {
+  position: absolute;
+  top: 2.25em;
+  left: 50%;
+  margin-left: -3.5em;
+  width: 8em;
+  text-align: center;
+}
+
 #turnorder .controls {
   position: absolute;
-  margin-top: 50px;
+  margin-top: 60px;
   margin-left: -47px;
 }
 
@@ -95,12 +104,13 @@
   border-style: solid;
 }
 
-#turnorder .phase {
+#turnorder .phase,
+#turnorder .stage {
   display: inline-block;
   background: #555;
   color: #eee;
-  padding: 5px;
-  margin-left: 10px;
+  padding: 3px 5px;
+  margin-left: 5px;
 }
 
 #turnorder .bgio-client {

--- a/examples/react-web/src/turnorder/simulator.js
+++ b/examples/react-web/src/turnorder/simulator.js
@@ -30,10 +30,11 @@ class Board extends React.Component {
 
   render() {
     if (this.props.playerID === null) {
+      const { phase } = this.props.ctx;
       return (
         <div className="table-interior">
           <label>phase</label>
-          <div className="phase">{this.props.ctx.phase}</div>
+          <div className="phase">{phase ? `'${phase}'` : 'null'}</div>
         </div>
       );
     }

--- a/examples/react-web/src/turnorder/simulator.js
+++ b/examples/react-web/src/turnorder/simulator.js
@@ -42,12 +42,14 @@ class Board extends React.Component {
     let className = 'player';
     let active = false;
     let current = false;
+    let stage;
     let onClick = () => {};
 
     if (this.props.ctx.activePlayers) {
       if (this.props.playerID in this.props.ctx.activePlayers) {
         className += ' active';
         active = true;
+        stage = this.props.ctx.activePlayers[this.props.playerID];
       }
     } else {
       if (this.props.playerID === this.props.ctx.currentPlayer) {
@@ -81,6 +83,15 @@ class Board extends React.Component {
         <span className={className} onClick={onClick}>
           {this.props.playerID}
         </span>
+
+        <div className="stage-label">
+          stage
+          {stage !== undefined ? (
+            <span className="stage">&apos;{stage}&apos;</span>
+          ) : (
+            ' undefined'
+          )}
+        </div>
 
         <div className="controls">
           {active && moves}

--- a/examples/react-web/src/turnorder/simulator.js
+++ b/examples/react-web/src/turnorder/simulator.js
@@ -34,7 +34,7 @@ class Board extends React.Component {
       return (
         <div className="table-interior">
           <label>phase</label>
-          <div className="phase">{phase ? `'${phase}'` : 'null'}</div>
+          <div className="phase">{phase || 'null'}</div>
         </div>
       );
     }
@@ -89,7 +89,7 @@ class Board extends React.Component {
 
         {stage !== undefined && (
           <div className="stage-label">
-            stage <span className="stage">&apos;{stage}&apos;</span>
+            stage <span className="stage">{stage || "''"}</span>
           </div>
         )}
 

--- a/examples/react-web/src/turnorder/simulator.js
+++ b/examples/react-web/src/turnorder/simulator.js
@@ -68,7 +68,7 @@ class Board extends React.Component {
 
     const events = Object.entries(this.props.events)
       .filter(() => current && active)
-      .filter(e => e[0] != 'setActionPlayers')
+      .filter(e => e[0] != 'setActivePlayers')
       .map(e => (
         <button key={e[0]} onClick={() => e[1]()}>
           {e[0]}

--- a/examples/react-web/src/turnorder/simulator.js
+++ b/examples/react-web/src/turnorder/simulator.js
@@ -63,11 +63,14 @@ class Board extends React.Component {
       current = true;
     }
 
-    const moves = Object.entries(this.props.moves).map(e => (
-      <button key={e[0]} onClick={() => e[1]()}>
-        {e[0]}
-      </button>
-    ));
+    const moves = Object.entries(this.props.moves)
+      .filter(e => !(e[0] === 'play' && stage === 'discard'))
+      .filter(e => !(e[0] === 'discard' && stage !== 'discard'))
+      .map(e => (
+        <button key={e[0]} onClick={() => e[1]()}>
+          {e[0]}
+        </button>
+      ));
 
     const events = Object.entries(this.props.events)
       .filter(() => current && active)

--- a/examples/react-web/src/turnorder/simulator.js
+++ b/examples/react-web/src/turnorder/simulator.js
@@ -13,7 +13,7 @@ import Default from './example-default';
 import Once from './example-once';
 import Custom from './example-custom';
 import CustomFrom from './example-custom-from';
-import Any from './example-any';
+import All from './example-all';
 import AllOnce from './example-all-once';
 import Others from './example-others';
 import OthersOnce from './example-others-once';
@@ -96,7 +96,7 @@ const examples = {
   once: Once,
   custom: Custom,
   'custom-from': CustomFrom,
-  any: Any,
+  all: All,
   'all-once': AllOnce,
   others: Others,
 };
@@ -153,10 +153,10 @@ class App extends React.Component {
             ONCE
           </div>
           <div
-            className={this.type === 'any' ? 'active' : ''}
-            onClick={() => this.init('any')}
+            className={this.type === 'all' ? 'active' : ''}
+            onClick={() => this.init('all')}
           >
-            ANY
+            ALL
           </div>
           <div
             className={this.type === 'all-once' ? 'active' : ''}

--- a/examples/react-web/src/turnorder/simulator.js
+++ b/examples/react-web/src/turnorder/simulator.js
@@ -14,7 +14,7 @@ import Once from './example-once';
 import Custom from './example-custom';
 import CustomFrom from './example-custom-from';
 import Any from './example-any';
-import AnyOnce from './example-any-once';
+import AllOnce from './example-all-once';
 import Others from './example-others';
 import OthersOnce from './example-others-once';
 import './simulator.css';
@@ -97,7 +97,7 @@ const examples = {
   custom: Custom,
   'custom-from': CustomFrom,
   any: Any,
-  'any-once': AnyOnce,
+  'all-once': AllOnce,
   others: Others,
 };
 
@@ -159,10 +159,10 @@ class App extends React.Component {
             ANY
           </div>
           <div
-            className={this.type === 'any-once' ? 'active' : ''}
-            onClick={() => this.init('any-once')}
+            className={this.type === 'all-once' ? 'active' : ''}
+            onClick={() => this.init('all-once')}
           >
-            ANY_ONCE
+            ALL_ONCE
           </div>
           <div
             className={this.type === 'others' ? 'active' : ''}

--- a/examples/react-web/src/turnorder/simulator.js
+++ b/examples/react-web/src/turnorder/simulator.js
@@ -87,14 +87,11 @@ class Board extends React.Component {
           {this.props.playerID}
         </span>
 
-        <div className="stage-label">
-          stage
-          {stage !== undefined ? (
-            <span className="stage">&apos;{stage}&apos;</span>
-          ) : (
-            ' undefined'
-          )}
-        </div>
+        {stage !== undefined && (
+          <div className="stage-label">
+            stage <span className="stage">&apos;{stage}&apos;</span>
+          </div>
+        )}
 
         <div className="controls">
           {active && moves}


### PR DESCRIPTION
As discussed in #442. Mainly this updates the turn order simulator, but I also fixed the Phases Diagram example.

Some of the turn order implementations are quite different after the overhaul, so you might want to check you’re happy with my interpretation of the originals.

I’ve tweaked the simulator by adding a display for the current stage of each player and made the phase show `null` when the phase is `null` (previously it would have been `'default'` in those cases).