### PR TITLE
Maintain currentPlayer/playOrderPos when phase ends

### DIFF
--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -559,7 +559,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     G = conf.onEnd(G, ctx);
 
     // Reset the phase.
-    ctx = { ...ctx, phase: null, playOrderPos: 0 };
+    ctx = { ...ctx, phase: null };
 
     // Add log entry.
     const action = gameEvent('endPhase', arg);

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -165,6 +165,20 @@ describe('phases', () => {
     state = flow.processGameEvent(state, gameEvent('endPhase'));
     expect(state.ctx.phase).toBe(null);
   });
+
+  test('maintain playOrderPos on phase end', () => {
+    const flow = Flow({
+      phases: { A: { start: true, next: 'B' }, B: { next: 'A' } },
+    });
+    let state = { G: {}, ctx: flow.ctx(3) };
+    state = flow.init(state);
+
+    expect(state.ctx.playOrderPos).toBe(0);
+    state = flow.processGameEvent(state, gameEvent('endTurn'));
+    expect(state.ctx.playOrderPos).toBe(1);
+    state = flow.processGameEvent(state, gameEvent('endPhase'));
+    expect(state.ctx.playOrderPos).toBe(1);
+  });
 });
 
 describe('turn', () => {

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -371,7 +371,7 @@ describe('turn', () => {
     state = flow.processMove(state, makeMove().payload);
 
     expect(state.ctx.phase).toBe('B');
-    expect(state.ctx.currentPlayer).toBe('0');
+    expect(state.ctx.currentPlayer).toBe('1');
     expect(state.ctx.turn).toBe(3);
   });
 });


### PR DESCRIPTION
Currently on phase end, `playOrderPos` is hard reset to `0`:

https://github.com/nicolodavis/boardgame.io/blob/a2961c81ce1393e3d6e789e33347ead180b33983/src/core/flow.js#L562

This could make sense, but it makes it difficult to create a phase which maintains or increments the current position when it starts. If `turn.order.first` tries to use `ctx.playOrderPos` or `ctx.currentPlayer`, they have already been reset.

This PR adds a test asserting `playOrderPos` shouldn’t change and removes the hard reset. It also changes one test that was now failing, but I think shouldn’t have been given the proposed changes.

I understand the simplicity of a new phase starting new play sequence, so maybe that could be maintained as a default, but `first: (G, ctx) => ctx.playOrderPos` should probably also return the prior position to be useful.

What if the reset to `0` only took place when `turn.order.first` is undefined? For now, this would be equivalent to modifying `TurnOrder.DEFAULT`, because its `first` isn’t currently doing anything (if I’ve understood this correctly):

```diff
DEFAULT: {
-  first: (G, ctx) => ctx.playOrderPos,
+  first: () => 0
  next: (G, ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
}
```