### PR TITLE
Enable `next` option for `setActivePlayers`

### DIFF
--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -673,7 +673,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     let conf = GetPhase(state.ctx);
 
     let { ctx } = state;
-    let { activePlayers, _activePlayersOnce, _prevActivePlayers } = state.ctx;
+    let { activePlayers, _activePlayersOnce, _prevActivePlayers } = ctx;
 
     if (_activePlayersOnce) {
       const playerID = action.playerID;
@@ -689,10 +689,10 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       if (ctx._nextActivePlayers) {
         ctx = SetActivePlayers(ctx, ctx._nextActivePlayers);
         ({ activePlayers, _activePlayersOnce, _prevActivePlayers } = ctx);
-      } else if (state.ctx._prevActivePlayers.length > 0) {
-        const lastIndex = state.ctx._prevActivePlayers.length - 1;
-        activePlayers = state.ctx._prevActivePlayers[lastIndex];
-        _prevActivePlayers = state.ctx._prevActivePlayers.slice(0, lastIndex);
+      } else if (_prevActivePlayers.length > 0) {
+        const lastIndex = _prevActivePlayers.length - 1;
+        activePlayers = _prevActivePlayers[lastIndex];
+        _prevActivePlayers = _prevActivePlayers.slice(0, lastIndex);
       } else {
         activePlayers = null;
         _activePlayersOnce = false;

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -672,6 +672,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
   function ProcessMove(state, action) {
     let conf = GetPhase(state.ctx);
 
+    let { ctx } = state;
     let { activePlayers, _activePlayersOnce, _prevActivePlayers } = state.ctx;
 
     if (_activePlayersOnce) {
@@ -685,7 +686,10 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     }
 
     if (activePlayers && Object.keys(activePlayers).length == 0) {
-      if (state.ctx._prevActivePlayers.length > 0) {
+      if (ctx._nextActivePlayers) {
+        ctx = SetActivePlayers(ctx, ctx._nextActivePlayers);
+        ({ activePlayers, _activePlayersOnce, _prevActivePlayers } = ctx);
+      } else if (state.ctx._prevActivePlayers.length > 0) {
         const lastIndex = state.ctx._prevActivePlayers.length - 1;
         activePlayers = state.ctx._prevActivePlayers[lastIndex];
         _prevActivePlayers = state.ctx._prevActivePlayers.slice(0, lastIndex);
@@ -703,7 +707,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     state = {
       ...state,
       ctx: {
-        ...state.ctx,
+        ...ctx,
         activePlayers,
         _activePlayersOnce,
         _prevActivePlayers,

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -41,6 +41,8 @@ export function SetActivePlayersEvent(state, arg) {
 export function SetActivePlayers(ctx, arg) {
   let { _prevActivePlayers } = ctx;
 
+  const _nextActivePlayers = arg.next || null;
+
   if (arg.revert) {
     _prevActivePlayers = _prevActivePlayers.concat(ctx.activePlayers);
   } else {
@@ -87,6 +89,7 @@ export function SetActivePlayers(ctx, arg) {
     activePlayers,
     _activePlayersOnce,
     _prevActivePlayers,
+    _nextActivePlayers,
   };
 }
 

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -540,6 +540,61 @@ describe('setActivePlayers', () => {
         _prevActivePlayers: [],
       });
     });
+
+    test('set to next', () => {
+      const game = {
+        moves: {
+          A: () => {},
+        },
+
+        turn: {
+          activePlayers: {
+            currentPlayer: 'stage1',
+            once: true,
+            next: {
+              currentPlayer: 'stage2',
+              once: true,
+              next: {
+                currentPlayer: 'stage3',
+              },
+            },
+          },
+        },
+      };
+
+      const reducer = CreateGameReducer({ game });
+      let state = InitializeGame({ game });
+
+      expect(state.ctx).toMatchObject({
+        activePlayers: { '0': 'stage1' },
+        _prevActivePlayers: [],
+        _nextActivePlayers: {
+          currentPlayer: 'stage2',
+          once: true,
+          next: {
+            currentPlayer: 'stage3',
+          },
+        },
+      });
+
+      state = reducer(state, makeMove('A', null, '0'));
+
+      expect(state.ctx).toMatchObject({
+        activePlayers: { '0': 'stage2' },
+        _prevActivePlayers: [],
+        _nextActivePlayers: {
+          currentPlayer: 'stage3',
+        },
+      });
+
+      state = reducer(state, makeMove('A', null, '0'));
+
+      expect(state.ctx).toMatchObject({
+        activePlayers: { '0': 'stage3' },
+        _prevActivePlayers: [],
+        _nextActivePlayers: null,
+      });
+    });
   });
 
   describe('militia', () => {


### PR DESCRIPTION
Continuing work towards #445

This enables a `next` option for `setActivePlayers`/`turn.activePlayers`, including support for nested `next` options.