### PR TITLE
feat: Support move limits in `setActivePlayers`

### DIFF
--- a/examples/react-web/src/turnorder/example-others-once.js
+++ b/examples/react-web/src/turnorder/example-others-once.js
@@ -11,7 +11,7 @@ import React from 'react';
 const code = `{
   moves: {
     play(G, ctx) {
-      ctx.events.setActivePlayers({ others: 'discard', once: true });
+      ctx.events.setActivePlayers({ others: 'discard', moveLimit: 1 });
       return G;
     },
   },
@@ -46,7 +46,7 @@ export default {
 
     moves: {
       play(G, ctx) {
-        ctx.events.setActivePlayers({ others: 'discard', once: true });
+        ctx.events.setActivePlayers({ others: 'discard', moveLimit: 1 });
         return G;
       },
     },

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -725,6 +725,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
         _prevActivePlayers = _prevActivePlayers.slice(0, lastIndex);
       } else {
         activePlayers = null;
+        _activePlayersMoveLimit = null;
       }
     }
 

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -739,9 +739,9 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       ctx: {
         ...ctx,
         activePlayers,
-        _prevActivePlayers,
         _activePlayersMoveLimit,
         _activePlayersNumMoves,
+        _prevActivePlayers,
         numMoves,
       },
     };

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -677,7 +677,14 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     let conf = GetPhase(state.ctx);
 
     let { ctx } = state;
-    let { activePlayers, _activePlayersOnce, _prevActivePlayers } = ctx;
+    let {
+      activePlayers,
+      _activePlayersNumMoves,
+      _activePlayersOnce,
+      _prevActivePlayers,
+    } = ctx;
+
+    if (activePlayers) _activePlayersNumMoves[action.playerID]++;
 
     if (_activePlayersOnce) {
       const playerID = action.playerID;
@@ -715,6 +722,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
         activePlayers,
         _activePlayersOnce,
         _prevActivePlayers,
+        _activePlayersNumMoves,
         numMoves,
       },
     };

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -729,7 +729,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     }
 
     let numMoves = state.ctx.numMoves;
-    if (action.playerID == state.ctx.currentPlayer) {
+    if (playerID == state.ctx.currentPlayer) {
       numMoves++;
     }
 

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -677,24 +677,44 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     let conf = GetPhase(state.ctx);
 
     let { ctx } = state;
-    let { activePlayers, _activePlayersNumMoves, _prevActivePlayers } = ctx;
+    let {
+      activePlayers,
+      _activePlayersMoveLimit,
+      _activePlayersNumMoves,
+      _prevActivePlayers,
+    } = ctx;
 
     if (activePlayers) _activePlayersNumMoves[action.playerID]++;
 
-    if (_activePlayersOnce) {
+    if (_activePlayersMoveLimit) {
       const playerID = action.playerID;
-      activePlayers = Object.keys(activePlayers)
-        .filter(id => id !== playerID)
-        .reduce((obj, key) => {
-          obj[key] = activePlayers[key];
-          return obj;
-        }, {});
+      if (
+        _activePlayersNumMoves[playerID] >= _activePlayersMoveLimit[playerID]
+      ) {
+        activePlayers = Object.keys(activePlayers)
+          .filter(id => id !== playerID)
+          .reduce((obj, key) => {
+            obj[key] = activePlayers[key];
+            return obj;
+          }, {});
+        _activePlayersMoveLimit = Object.keys(_activePlayersMoveLimit)
+          .filter(id => id !== playerID)
+          .reduce((obj, key) => {
+            obj[key] = _activePlayersMoveLimit[key];
+            return obj;
+          }, {});
+      }
     }
 
     if (activePlayers && Object.keys(activePlayers).length == 0) {
       if (ctx._nextActivePlayers) {
         ctx = SetActivePlayers(ctx, ctx._nextActivePlayers);
-        ({ activePlayers, _prevActivePlayers } = ctx);
+        ({
+          activePlayers,
+          _activePlayersMoveLimit,
+          _activePlayersNumMoves,
+          _prevActivePlayers,
+        } = ctx);
       } else if (_prevActivePlayers.length > 0) {
         const lastIndex = _prevActivePlayers.length - 1;
         activePlayers = _prevActivePlayers[lastIndex];
@@ -715,6 +735,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
         ...ctx,
         activePlayers,
         _prevActivePlayers,
+        _activePlayersMoveLimit,
         _activePlayersNumMoves,
         numMoves,
       },

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -684,26 +684,26 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       _prevActivePlayers,
     } = ctx;
 
-    if (activePlayers) _activePlayersNumMoves[action.playerID]++;
+    const { playerID } = action;
 
-    if (_activePlayersMoveLimit) {
-      const playerID = action.playerID;
-      if (
-        _activePlayersNumMoves[playerID] >= _activePlayersMoveLimit[playerID]
-      ) {
-        activePlayers = Object.keys(activePlayers)
-          .filter(id => id !== playerID)
-          .reduce((obj, key) => {
-            obj[key] = activePlayers[key];
-            return obj;
-          }, {});
-        _activePlayersMoveLimit = Object.keys(_activePlayersMoveLimit)
-          .filter(id => id !== playerID)
-          .reduce((obj, key) => {
-            obj[key] = _activePlayersMoveLimit[key];
-            return obj;
-          }, {});
-      }
+    if (activePlayers) _activePlayersNumMoves[playerID]++;
+
+    if (
+      _activePlayersMoveLimit &&
+      _activePlayersNumMoves[playerID] >= _activePlayersMoveLimit[playerID]
+    ) {
+      activePlayers = Object.keys(activePlayers)
+        .filter(id => id !== playerID)
+        .reduce((obj, key) => {
+          obj[key] = activePlayers[key];
+          return obj;
+        }, {});
+      _activePlayersMoveLimit = Object.keys(_activePlayersMoveLimit)
+        .filter(id => id !== playerID)
+        .reduce((obj, key) => {
+          obj[key] = _activePlayersMoveLimit[key];
+          return obj;
+        }, {});
     }
 
     if (activePlayers && Object.keys(activePlayers).length == 0) {

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -717,7 +717,11 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
         } = ctx);
       } else if (_prevActivePlayers.length > 0) {
         const lastIndex = _prevActivePlayers.length - 1;
-        activePlayers = _prevActivePlayers[lastIndex];
+        ({
+          activePlayers,
+          _activePlayersMoveLimit,
+          _activePlayersNumMoves,
+        } = _prevActivePlayers[lastIndex]);
         _prevActivePlayers = _prevActivePlayers.slice(0, lastIndex);
       } else {
         activePlayers = null;

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -677,12 +677,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     let conf = GetPhase(state.ctx);
 
     let { ctx } = state;
-    let {
-      activePlayers,
-      _activePlayersNumMoves,
-      _activePlayersOnce,
-      _prevActivePlayers,
-    } = ctx;
+    let { activePlayers, _activePlayersNumMoves, _prevActivePlayers } = ctx;
 
     if (activePlayers) _activePlayersNumMoves[action.playerID]++;
 
@@ -699,14 +694,13 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     if (activePlayers && Object.keys(activePlayers).length == 0) {
       if (ctx._nextActivePlayers) {
         ctx = SetActivePlayers(ctx, ctx._nextActivePlayers);
-        ({ activePlayers, _activePlayersOnce, _prevActivePlayers } = ctx);
+        ({ activePlayers, _prevActivePlayers } = ctx);
       } else if (_prevActivePlayers.length > 0) {
         const lastIndex = _prevActivePlayers.length - 1;
         activePlayers = _prevActivePlayers[lastIndex];
         _prevActivePlayers = _prevActivePlayers.slice(0, lastIndex);
       } else {
         activePlayers = null;
-        _activePlayersOnce = false;
       }
     }
 
@@ -720,7 +714,6 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       ctx: {
         ...ctx,
         activePlayers,
-        _activePlayersOnce,
         _prevActivePlayers,
         _activePlayersNumMoves,
         numMoves,

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -124,10 +124,10 @@ export function SetActivePlayers(ctx, arg) {
   return {
     ...ctx,
     activePlayers,
-    _prevActivePlayers,
-    _nextActivePlayers,
     _activePlayersMoveLimit,
     _activePlayersNumMoves,
+    _prevActivePlayers,
+    _nextActivePlayers,
   };
 }
 

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -50,7 +50,6 @@ export function SetActivePlayers(ctx, arg) {
   }
 
   let activePlayers = {};
-  let _activePlayersOnce = false;
 
   if (arg.value) {
     activePlayers = arg.value;
@@ -74,10 +73,6 @@ export function SetActivePlayers(ctx, arg) {
       const playerID = ctx.playOrder[i];
       activePlayers[playerID] = arg.all;
     }
-  }
-
-  if (arg.once) {
-    _activePlayersOnce = true;
   }
 
   if (Object.keys(activePlayers).length == 0) {
@@ -131,7 +126,6 @@ export function SetActivePlayers(ctx, arg) {
   return {
     ...ctx,
     activePlayers,
-    _activePlayersOnce,
     _prevActivePlayers,
     _nextActivePlayers,
     _activePlayersMoveLimit,

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -331,7 +331,7 @@ export const ActivePlayers = {
    * This is typically used in a phase where you want to elicit a response
    * from every player in the game.
    */
-  ALL_ONCE: { all: Stage.NULL, once: true },
+  ALL_ONCE: { all: Stage.NULL, moveLimit: 1 },
 
   /**
    * OTHERS
@@ -348,5 +348,5 @@ export const ActivePlayers = {
    * This is typically used in a phase where you want to elicit a response
    * from every *other* player in the game.
    */
-  OTHERS_ONCE: { others: Stage.NULL, once: true },
+  OTHERS_ONCE: { others: Stage.NULL, moveLimit: 1 },
 };

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -117,7 +117,7 @@ export function SetActivePlayers(ctx, arg) {
   }
 
   let _activePlayersNumMoves = {};
-  for (var id in activePlayers) {
+  for (const id in activePlayers) {
     _activePlayersNumMoves[id] = 0;
   }
 

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -123,6 +123,11 @@ export function SetActivePlayers(ctx, arg) {
     }
   }
 
+  let _activePlayersNumMoves = {};
+  for (var id in activePlayers) {
+    _activePlayersNumMoves[id] = 0;
+  }
+
   return {
     ...ctx,
     activePlayers,
@@ -130,6 +135,7 @@ export function SetActivePlayers(ctx, arg) {
     _prevActivePlayers,
     _nextActivePlayers,
     _activePlayersMoveLimit,
+    _activePlayersNumMoves,
   };
 }
 

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -85,13 +85,11 @@ export function SetActivePlayers(ctx, arg) {
 
   let _activePlayersMoveLimit = null;
 
-  if (arg.moveLimit) {
+  if (activePlayers && arg.moveLimit) {
     if (typeof arg.moveLimit === 'number') {
-      if (activePlayers) {
-        _activePlayersMoveLimit = {};
-        for (const id in activePlayers) {
-          _activePlayersMoveLimit[id] = arg.moveLimit;
-        }
+      _activePlayersMoveLimit = {};
+      for (const id in activePlayers) {
+        _activePlayersMoveLimit[id] = arg.moveLimit;
       }
     } else {
       _activePlayersMoveLimit = {};

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -84,12 +84,52 @@ export function SetActivePlayers(ctx, arg) {
     activePlayers = null;
   }
 
+  let _activePlayersMoveLimit = null;
+
+  if (arg.moveLimit) {
+    if (typeof arg.moveLimit === 'number') {
+      if (activePlayers) {
+        _activePlayersMoveLimit = {};
+        for (const id in activePlayers) {
+          _activePlayersMoveLimit[id] = arg.moveLimit;
+        }
+      }
+    } else {
+      _activePlayersMoveLimit = {};
+
+      if (arg.moveLimit.value) {
+        _activePlayersMoveLimit = arg.moveLimit.value;
+      }
+
+      if (
+        arg.moveLimit.currentPlayer !== undefined &&
+        activePlayers[ctx.currentPlayer]
+      ) {
+        _activePlayersMoveLimit[ctx.currentPlayer] =
+          arg.moveLimit.currentPlayer;
+      }
+
+      if (arg.moveLimit.others !== undefined) {
+        for (const id in activePlayers) {
+          if (id !== ctx.currentPlayer) {
+            _activePlayersMoveLimit[id] = arg.moveLimit.others;
+          }
+        }
+      }
+
+      if (Object.keys(activePlayers).length == 0) {
+        activePlayers = null;
+      }
+    }
+  }
+
   return {
     ...ctx,
     activePlayers,
     _activePlayersOnce,
     _prevActivePlayers,
     _nextActivePlayers,
+    _activePlayersMoveLimit,
   };
 }
 

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -115,10 +115,6 @@ export function SetActivePlayers(ctx, arg) {
           }
         }
       }
-
-      if (Object.keys(activePlayers).length == 0) {
-        activePlayers = null;
-      }
     }
   }
 

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -44,7 +44,11 @@ export function SetActivePlayers(ctx, arg) {
   const _nextActivePlayers = arg.next || null;
 
   if (arg.revert) {
-    _prevActivePlayers = _prevActivePlayers.concat(ctx.activePlayers);
+    _prevActivePlayers = _prevActivePlayers.concat({
+      activePlayers: ctx.activePlayers,
+      _activePlayersMoveLimit: ctx._activePlayersMoveLimit,
+      _activePlayersNumMoves: ctx._activePlayersNumMoves,
+    });
   } else {
     _prevActivePlayers = [];
   }

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -530,7 +530,13 @@ describe('setActivePlayers', () => {
 
       expect(state.ctx).toMatchObject({
         activePlayers: { '0': 'stage2' },
-        _prevActivePlayers: [{ '0': 'stage1' }],
+        _prevActivePlayers: [
+          {
+            activePlayers: { '0': 'stage1' },
+            _activePlayersMoveLimit: null,
+            _activePlayersNumMoves: { '0': 1 },
+          },
+        ],
       });
 
       state = reducer(state, makeMove('B', null, '0'));

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -774,6 +774,45 @@ describe('setActivePlayers', () => {
       expect(state.ctx.activePlayers).toBeNull();
     });
 
+    test('value syntax', () => {
+      const game = {
+        turn: {
+          activePlayers: {
+            all: 'play',
+            moveLimit: {
+              value: { '0': 1, '1': 2, '2': 3 },
+            },
+          },
+          stages: {
+            play: { moves: { A: () => {} } },
+          },
+        },
+      };
+
+      const reducer = CreateGameReducer({ game });
+      let state = InitializeGame({ game, numPlayers: 3 });
+
+      expect(state.ctx._activePlayersMoveLimit).toEqual({
+        '0': 1,
+        '1': 2,
+        '2': 3,
+      });
+
+      state = reducer(state, makeMove('A', null, '0'));
+      state = reducer(state, makeMove('A', null, '1'));
+      state = reducer(state, makeMove('A', null, '2'));
+
+      expect(state.ctx.activePlayers).toEqual({ '1': 'play', '2': 'play' });
+
+      state = reducer(state, makeMove('A', null, '1'));
+      state = reducer(state, makeMove('A', null, '2'));
+
+      expect(state.ctx.activePlayers).toEqual({ '2': 'play' });
+
+      state = reducer(state, makeMove('A', null, '2'));
+      expect(state.ctx.activePlayers).toBeNull();
+    });
+
     test('move counts reset on turn end', () => {
       const game = {
         turn: {

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -422,7 +422,7 @@ describe('setActivePlayers', () => {
         B: (G, ctx) => {
           ctx.events.setActivePlayers({
             value: { '0': Stage.NULL, '1': Stage.NULL },
-            once: true,
+            moveLimit: 1,
           });
           return G;
         },
@@ -446,7 +446,7 @@ describe('setActivePlayers', () => {
       moves: {
         B: (G, ctx) => {
           ctx.events.setActivePlayers({
-            once: true,
+            moveLimit: 1,
             others: Stage.NULL,
           });
           return G;
@@ -480,7 +480,7 @@ describe('setActivePlayers', () => {
         },
 
         turn: {
-          activePlayers: { currentPlayer: 'stage', once: true },
+          activePlayers: { currentPlayer: 'stage', moveLimit: 1 },
         },
       };
 
@@ -506,7 +506,7 @@ describe('setActivePlayers', () => {
           A: (G, ctx) => {
             ctx.events.setActivePlayers({
               currentPlayer: 'stage2',
-              once: true,
+              moveLimit: 1,
               revert: true,
             });
           },
@@ -550,10 +550,10 @@ describe('setActivePlayers', () => {
         turn: {
           activePlayers: {
             currentPlayer: 'stage1',
-            once: true,
+            moveLimit: 1,
             next: {
               currentPlayer: 'stage2',
-              once: true,
+              moveLimit: 1,
               next: {
                 currentPlayer: 'stage3',
               },
@@ -570,7 +570,7 @@ describe('setActivePlayers', () => {
         _prevActivePlayers: [],
         _nextActivePlayers: {
           currentPlayer: 'stage2',
-          once: true,
+          moveLimit: 1,
           next: {
             currentPlayer: 'stage3',
           },
@@ -611,7 +611,7 @@ describe('setActivePlayers', () => {
                 militia: (G, ctx) => {
                   ctx.events.setActivePlayers({
                     others: 'B',
-                    once: true,
+                    moveLimit: 1,
                     revert: true,
                   });
                 },


### PR DESCRIPTION
Continuing work towards #445 

- [X] Support `moveLimit` option in `setActivePlayers`, storing result in `ctx._activePlayersMoveLimit`

- [x] Track moves by currently active players in `ctx._activePlayersNumMoves`

- [x] Reset player counts whenever `setActivePlayers` is called and when the turn ends

- [x] End stages when player has reached move limit

- [x] Remove `once` option in favour of `moveLimit`

- [x] Restore previous move limits and counts when using `revert: true`