### PR TITLE
docs: Fix some more changes in Turn Order docs

### DIFF
--- a/docs/documentation/turn-order.md
+++ b/docs/documentation/turn-order.md
@@ -181,23 +181,28 @@ export const game = {
 
 ### Implementing a custom turn order
 
-A `turn.order` object has the following structure:
+The following settings inside `turn` affect turn order:
 
 ```js
-{
+const turn = {
   // OPTIONAL:
-  // Override the initial value of playOrder.
-  // This is called at the beginning of the phase.
-  playOrder: (G, ctx) => [...],
+  // If this section is present, it will override the DEFAULT
+  // turn order.
+  order: {
+    // OPTIONAL:
+    // Override the initial value of playOrder.
+    // This is called at the beginning of the phase.
+    playOrder: (G, ctx) => [...],
 
-  // Get the initial value of playOrderPos.
-  // This is called at the beginning of the phase.
-  first: (G, ctx) => 0,
+    // Get the initial value of playOrderPos.
+    // This is called at the beginning of the phase.
+    first: (G, ctx) => 0,
 
-  // Get the next value of playOrderPos.
-  // This is called at the end of each turn.
-  // The phase ends if this returns undefined.
-  next: (G, ctx) => (ctx.playOrderPos + 1) % ctx.numPlayers,
+    // Get the next value of playOrderPos.
+    // This is called at the end of each turn.
+    // The phase ends if this returns undefined.
+    next: (G, ctx) => (ctx.playOrderPos + 1) % ctx.numPlayers,
+  },
 
   // OPTIONAL:
   // If this section is present, activePlayers is modified

--- a/docs/documentation/turn-order.md
+++ b/docs/documentation/turn-order.md
@@ -237,6 +237,16 @@ const turn = {
       currentPlayer: true
     },
   },
+
+  // OPTIONAL:
+  // Limits the number of moves the current player can make
+  // during the turn. Once the limit is reached the turn ends.
+  moveLimit: 2,
+
+  // OPTIONAL:
+  // A function that returns a truthy value if the turn should end.
+  // It can also return the player for the next turn (see below).
+  endIf: (G, ctx) => {}
 }
 ```
 

--- a/docs/documentation/turn-order.md
+++ b/docs/documentation/turn-order.md
@@ -149,38 +149,34 @@ requires every other player in the game to discard a card.
 ### Specifying a turn order
 
 You can change the turn order by using the `turn.order` option.
-This is passed inside a `flow` section of the `Game` configuration:
+This can be passed inside your game configuration:
 
 ```js
-import { Game, TurnOrder, ActivePlayers } from 'boardgame.io/core';
+import { TurnOrder, ActivePlayers } from 'boardgame.io/core';
 
-Game({
-  flow: {
-    turn: {
-      order: TurnOrder.DEFAULT,
-      activePlayers: ActivePlayers.ALL,
-    }
-  }
-}
+export const game = {
+  turn: {
+    order: TurnOrder.DEFAULT,
+    activePlayers: ActivePlayers.ALL,
+  },
+};
 ```
 
 Turn orders can also be specified on a per-phase level.
 
 ```js
-import { Game, TurnOrder, ActivePlayers } from 'boardgame.io/core';
+import { TurnOrder, ActivePlayers } from 'boardgame.io/core';
 
-Game({
-  flow: {
-    phases: {
-      A: {
-        turn: { activePlayers: ActivePlayers.ALL }
-      },
-      B: {
-        turn: { order: TurnOrder.ONCE }
-      },
+export const game = {
+  phases: {
+    A: {
+      turn: { activePlayers: ActivePlayers.ALL },
     },
-  }
-}
+    B: {
+      turn: { order: TurnOrder.ONCE },
+    },
+  },
+};
 ```
 
 ### Implementing a custom turn order
@@ -260,9 +256,9 @@ onClickEndTurn() {
 ```
 
 ```js
-flow: {
+const game = {
   turn: {
     endIf: (G, ctx) => ({ next: '3' }),
-  }
-}
+  },
+};
 ```


### PR DESCRIPTION
- Remove references to `flow` and `Game` in turn-order.md
- Fix `turn` docs, splitting `turn.order` & `turn.activePlayers`
- Add `moveLimit` and `endIf` to `turn` docs 