### PR TITLE
refactor: Change moveLimit syntax in setActivePlayers

### DIFF
--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -195,7 +195,7 @@ function ApplyActivePlayerArgument(
   playerID,
   arg
 ) {
-  if (typeof arg !== 'object' || arg === null) {
+  if (typeof arg !== 'object' || arg === Stage.NULL) {
     arg = { stage: arg };
   }
 

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -89,6 +89,14 @@ export function SetActivePlayers(ctx, playerID, arg) {
     }
   }
 
+  if (arg.moveLimit) {
+    for (const id in localCtx.activePlayers) {
+      if (localCtx._activePlayersMoveLimit[id] === undefined) {
+        localCtx._activePlayersMoveLimit[id] = arg.moveLimit;
+      }
+    }
+  }
+
   if (Object.keys(localCtx.activePlayers).length == 0) {
     localCtx.activePlayers = null;
   }

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -51,33 +51,45 @@ export function SetActivePlayers(ctx, playerID, arg) {
     _prevActivePlayers = [];
   }
 
-  let localCtx = {
-    activePlayers: {},
-    _activePlayersMoveLimit: {},
-  };
+  let activePlayers = {};
+  let _activePlayersMoveLimit = {};
 
   if (Array.isArray(arg)) {
     let value = {};
     arg.forEach(v => (value[v] = Stage.NULL));
-    localCtx.activePlayers = value;
+    activePlayers = value;
   }
 
   if (arg.value) {
     for (const id in arg.value) {
-      const value = arg.value[id];
-      localCtx = ApplyActivePlayerArgument(localCtx, id, value);
+      ApplyActivePlayerArgument(
+        activePlayers,
+        _activePlayersMoveLimit,
+        id,
+        arg.value[id]
+      );
     }
   }
 
   if (arg.player !== undefined) {
-    localCtx = ApplyActivePlayerArgument(localCtx, playerID, arg.player);
+    ApplyActivePlayerArgument(
+      activePlayers,
+      _activePlayersMoveLimit,
+      playerID,
+      arg.player
+    );
   }
 
   if (arg.others !== undefined) {
     for (let i = 0; i < ctx.playOrder.length; i++) {
       const id = ctx.playOrder[i];
       if (id !== playerID) {
-        localCtx = ApplyActivePlayerArgument(localCtx, id, arg.others);
+        ApplyActivePlayerArgument(
+          activePlayers,
+          _activePlayersMoveLimit,
+          id,
+          arg.others
+        );
       }
     }
   }
@@ -85,34 +97,40 @@ export function SetActivePlayers(ctx, playerID, arg) {
   if (arg.all !== undefined) {
     for (let i = 0; i < ctx.playOrder.length; i++) {
       const id = ctx.playOrder[i];
-      localCtx = ApplyActivePlayerArgument(localCtx, id, arg.all);
+      ApplyActivePlayerArgument(
+        activePlayers,
+        _activePlayersMoveLimit,
+        id,
+        arg.all
+      );
     }
   }
 
   if (arg.moveLimit) {
-    for (const id in localCtx.activePlayers) {
-      if (localCtx._activePlayersMoveLimit[id] === undefined) {
-        localCtx._activePlayersMoveLimit[id] = arg.moveLimit;
+    for (const id in activePlayers) {
+      if (_activePlayersMoveLimit[id] === undefined) {
+        _activePlayersMoveLimit[id] = arg.moveLimit;
       }
     }
   }
 
-  if (Object.keys(localCtx.activePlayers).length == 0) {
-    localCtx.activePlayers = null;
+  if (Object.keys(activePlayers).length == 0) {
+    activePlayers = null;
   }
 
-  if (Object.keys(localCtx._activePlayersMoveLimit).length == 0) {
-    localCtx._activePlayersMoveLimit = null;
+  if (Object.keys(_activePlayersMoveLimit).length == 0) {
+    _activePlayersMoveLimit = null;
   }
 
   let _activePlayersNumMoves = {};
-  for (const id in localCtx.activePlayers) {
+  for (const id in activePlayers) {
     _activePlayersNumMoves[id] = 0;
   }
 
   return {
     ...ctx,
-    ...localCtx,
+    activePlayers,
+    _activePlayersMoveLimit,
     _activePlayersNumMoves,
     _prevActivePlayers,
     _nextActivePlayers,
@@ -166,23 +184,25 @@ export function UpdateActivePlayersOnceEmpty(ctx) {
 
 /**
  * Apply an active player argument to the given player ID
- * @param {Object} ctx A context object
+ * @param {Object} activePlayers
+ * @param {Object} _activePlayersMoveLimit
  * @param {String} playerID The player to apply the parameter to
  * @param {(String|Object)} arg An active player argument
  */
-function ApplyActivePlayerArgument(ctx, playerID, arg) {
+function ApplyActivePlayerArgument(
+  activePlayers,
+  _activePlayersMoveLimit,
+  playerID,
+  arg
+) {
   if (typeof arg !== 'object' || arg === null) {
     arg = { stage: arg };
   }
 
-  if (arg.stage === undefined) return ctx;
-
-  let { activePlayers, _activePlayersMoveLimit } = ctx;
-
-  activePlayers[playerID] = arg.stage;
-  if (arg.moveLimit) _activePlayersMoveLimit[playerID] = arg.moveLimit;
-
-  return { ...ctx, activePlayers, _activePlayersMoveLimit };
+  if (arg.stage !== undefined) {
+    activePlayers[playerID] = arg.stage;
+    if (arg.moveLimit) _activePlayersMoveLimit[playerID] = arg.moveLimit;
+  }
 }
 
 /**

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -419,7 +419,7 @@ describe('setActivePlayers', () => {
   test('undefined stage leaves player inactive', () => {
     const newState = flow.processEvent(
       state,
-      gameEvent('setActivePlayers', [{ value: { '1': { stage: undefined } } }])
+      gameEvent('setActivePlayers', [{ value: { '1': { moveLimit: 2 } } }])
     );
     expect(newState.ctx.activePlayers).toBeNull();
   });

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -416,6 +416,14 @@ describe('setActivePlayers', () => {
     });
   });
 
+  test('undefined stage leaves player inactive', () => {
+    const newState = flow.processEvent(
+      state,
+      gameEvent('setActivePlayers', [{ value: { '1': { stage: undefined } } }])
+    );
+    expect(newState.ctx.activePlayers).toBeNull();
+  });
+
   test('all', () => {
     const newState = flow.processEvent(
       state,
@@ -780,6 +788,27 @@ describe('setActivePlayers', () => {
       state = reducer(state, makeMove('A', null, '0'));
 
       expect(state.ctx.activePlayers).toBeNull();
+    });
+
+    test('player-specific limit overrides moveLimit arg', () => {
+      const game = {
+        turn: {
+          activePlayers: {
+            all: { stage: 'play', moveLimit: 2 },
+            moveLimit: 1,
+          },
+          stages: {
+            play: { moves: { A: () => {} } },
+          },
+        },
+      };
+
+      let state = InitializeGame({ game, numPlayers: 2 });
+
+      expect(state.ctx._activePlayersMoveLimit).toEqual({
+        '0': 2,
+        '1': 2,
+      });
     });
 
     test('value syntax', () => {

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -741,11 +741,8 @@ describe('setActivePlayers', () => {
       const game = {
         turn: {
           activePlayers: {
-            all: 'play',
-            moveLimit: {
-              player: 2,
-              others: 1,
-            },
+            player: { stage: 'play', moveLimit: 2 },
+            others: { stage: 'play', moveLimit: 1 },
           },
           stages: {
             play: { moves: { A: () => {} } },
@@ -789,9 +786,10 @@ describe('setActivePlayers', () => {
       const game = {
         turn: {
           activePlayers: {
-            all: 'play',
-            moveLimit: {
-              value: { '0': 1, '1': 2, '2': 3 },
+            value: {
+              '0': { stage: 'play', moveLimit: 1 },
+              '1': { stage: 'play', moveLimit: 2 },
+              '2': { stage: 'play', moveLimit: 3 },
             },
           },
           stages: {

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -797,9 +797,6 @@ describe('setActivePlayers', () => {
             all: { stage: 'play', moveLimit: 2 },
             moveLimit: 1,
           },
-          stages: {
-            play: { moves: { A: () => {} } },
-          },
         },
       };
 


### PR DESCRIPTION
Closes #479 

#### Design choices

- Player-specific move limits take precedence. For example, the following sets the player’s move limit to 2, not 1:

    ```js
    setActivePlayers({
      player: { stage: 'A', moveLimit: 2 },
      moveLimit: 1,
    })
    ```

- I wrote a helper `ApplyActivePlayerArgument()`, to simplify setting a player’s stage and move limit given an argument that can be a stage (`string`, `boolean`, `number`, `null`) or an object (shape: `{ stage, moveLimit }`). It sacrifices a little bit of efficiency, because parsing the argument happens for every player (for example for `all` and `others`) instead of once and then applied for all. I think it’s still cleaner to separate this logic out into a single function.

- Setting a move limit with the long-form syntax *requires* an accompanying stage field, so the following would not apply a limit:

    ```js
    setActivePlayers({
      all: { stage: 'A' },
      player: { moveLimit: 2 },
    });
    ```