### PR TITLE
fix: Move player to “next” stage on `endStage`

### DIFF
--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -553,14 +553,20 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
     let { ctx } = state;
     let { activePlayers, _activePlayersMoveLimit } = ctx;
 
+    const playerInStage = activePlayers !== null && playerID in activePlayers;
+
+    if (!arg && playerInStage) {
+      const conf = GetPhase(ctx);
+      const stage = conf.turn.stages[activePlayers[playerID]];
+      if (stage && stage.next) arg = stage.next;
+    }
+
     if (next && arg) {
       next.push({ fn: UpdateStage, arg, playerID });
     }
 
     // If player isn’t in a stage, there is nothing else to do.
-    if (activePlayers === null || !(playerID in activePlayers)) {
-      return state;
-    }
+    if (!playerInStage) return state;
 
     // Remove player from activePlayers.
     activePlayers = Object.keys(activePlayers)

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -569,6 +569,39 @@ describe('stage events', () => {
       state = flow.processEvent(state, gameEvent('endStage'));
       expect(state.ctx._activePlayersNumMoves).toMatchObject({ '0': 1 });
     });
+
+    test('sets to next', () => {
+      let flow = Flow({
+        turn: {
+          activePlayers: { player: 'A1', others: 'B1' },
+          stages: {
+            A1: { next: 'A2' },
+            B1: { next: 'B2' },
+          },
+        },
+      });
+      let state = { G: {}, ctx: flow.ctx(2) };
+      state = flow.init(state);
+
+      expect(state.ctx.activePlayers).toMatchObject({
+        '0': 'A1',
+        '1': 'B1',
+      });
+
+      state = flow.processEvent(state, gameEvent('endStage', null, '0'));
+
+      expect(state.ctx.activePlayers).toMatchObject({
+        '0': 'A2',
+        '1': 'B1',
+      });
+
+      state = flow.processEvent(state, gameEvent('endStage', null, '1'));
+
+      expect(state.ctx.activePlayers).toMatchObject({
+        '0': 'A2',
+        '1': 'B2',
+      });
+    });
   });
 });
 


### PR DESCRIPTION
The new docs [describe a `next` option in the config for stages](https://boardgame.io/documentation/#/stages?id=exiting-stages), but this wasn’t actually implemented.

This PR adds a test for that behaviour and fixes it.