### PR TITLE
docs: Improve documentation around bots and `step()`

### DIFF
--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -102,13 +102,16 @@ The `Board` component will receive the following as `props`:
 
 7. `redo`: Function that redoes the previously undone move.
 
-8. `log`: The game log.
+8. `step`:
+   Function that will advance the game if [AI is configured](/tutorial.md#bots).
 
-9. `gameID`: The game ID associated with the client.
+9. `log`: The game log.
 
-10. `playerID`: The player ID associated with the client.
+10. `gameID`: The game ID associated with the client.
 
-11. `gameMetadata`: An object containing the players that have joined the game from a [room](/api/Lobby.md).
+11. `playerID`: The player ID associated with the client.
+
+12. `gameMetadata`: An object containing the players that have joined the game from a [room](/api/Lobby.md).
 
 Example:
 
@@ -127,9 +130,9 @@ Example:
 }
 ```
 
-12. `isActive`: `true` if the client is able to currently make
+13. `isActive`: `true` if the client is able to currently make
     a move or interact with the game.
 
-13. `isMultiplayer`: `true` if it is a multiplayer game.
+14. `isMultiplayer`: `true` if it is a multiplayer game.
 
-14. `isConnected`: `true` if connection to the server is active.
+15. `isConnected`: `true` if connection to the server is active.

--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -111,24 +111,25 @@ The `Board` component will receive the following as `props`:
 
 11. `playerID`: The player ID associated with the client.
 
-12. `gameMetadata`: An object containing the players that have joined the game from a [room](/api/Lobby.md).
+12. `gameMetadata`: An object containing the players that have joined
+    the game from a [room](/api/Lobby.md).
 
-Example:
+    Example:
 
-```json
-{
-  "players": {
-    "0": {
-      "id": 0,
-      "name": "Alice"
-    },
-    "1": {
-      "id": 1,
-      "name": "Bob"
+    ```json
+    {
+      "players": {
+        "0": {
+          "id": 0,
+          "name": "Alice"
+        },
+        "1": {
+          "id": 1,
+          "name": "Bob"
+        }
+      }
     }
-  }
-}
-```
+    ```
 
 13. `isActive`: `true` if the client is able to currently make
     a move or interact with the game.

--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -137,3 +137,6 @@ The `Board` component will receive the following as `props`:
 14. `isMultiplayer`: `true` if it is a multiplayer game.
 
 15. `isConnected`: `true` if connection to the server is active.
+
+16. `credentials`: Authentication token for this player when using
+    the [Lobby REST API](/api/Lobby.md#server-side-api).

--- a/docs/documentation/tutorial.md
+++ b/docs/documentation/tutorial.md
@@ -292,16 +292,19 @@ const App = Client({
 export default App;
 ```
 
-That's it! You will notice that you now have two more options in
-the **Controls** section (`step` and `simulate`). You can use the
-keyboard shortcuts `4` and `5` to trigger them.
+That's it! Now that you have configured AI, there are two more options in
+the **Controls** section of the Debug Panel:
 
-Press `5` and just watch your game play by itself!
+- `step` causes the AI to calculate and make a single move
+  (shortcut: <kbd>4</kbd>)
 
-You can also use a combination of moves that you make yourself
-and bot moves (press `4` to have the bot make a move). You can make
+- `simulate` causes the AI to play the entire game by itself
+  (shortcut: <kbd>5</kbd>)
+
+`step` helps you combine moves that you make yourself
+and bot moves. For example, you can make
 some manual moves to get two in a row and then verify that
-the bot makes a block, for example.
+the bot makes a block.
 
 ```react
 <iframe class='react' src='snippets/example-3' height='850' scrolling='no' title='example' frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'></iframe>

--- a/docs/documentation/tutorial.md
+++ b/docs/documentation/tutorial.md
@@ -325,7 +325,7 @@ class TicTacToeBoard extends React.Component {
     if (this.isActive(id)) {
       this.props.moves.clickCell(id);
       this.props.events.endTurn();
-      +setTimeout(() => this.props.step(), 1000);
+      setTimeout(() => this.props.step(), 1000);
     }
   }
 

--- a/docs/documentation/tutorial.md
+++ b/docs/documentation/tutorial.md
@@ -315,29 +315,6 @@ hood to explore the game tree and find good moves. The default uses 1000 iterati
 move, which isn't sufficient to create a bullet-proof tic-tac-toe player. This can be
 configured to adjust the bot strength.
 
-If you want to call `step` from the React client, it is passed as one of the
-props to your `<Board>` component. Adapting our previous example, we could add
-a call to `step` each time the human player clicks on a cell:
-
-```js
-class TicTacToeBoard extends React.Component {
-  onClick(id) {
-    if (this.isActive(id)) {
-      this.props.moves.clickCell(id);
-      this.props.events.endTurn();
-      setTimeout(() => this.props.step(), 1000);
-    }
-  }
-
-  // ...
-}
-```
-
-We’re missing some checks to make sure the `clickCell` move was valid
-before activating the bot or to prevent multiple timeouts if the player
-clicks several times, but this demonstrates a basic use of `step`.
-A better API for AI-enabled games will be added as the framework develops.
-
 The framework will come bundled with a few different bot algorithms, and an advanced
 version of MCTS that will allow you to specify a set of objectives to optimize for.
 For example, at any given point in the game you can tell the bot to gather resources

--- a/docs/documentation/tutorial.md
+++ b/docs/documentation/tutorial.md
@@ -315,6 +315,29 @@ hood to explore the game tree and find good moves. The default uses 1000 iterati
 move, which isn't sufficient to create a bullet-proof tic-tac-toe player. This can be
 configured to adjust the bot strength.
 
+If you want to call `step` from the React client, it is passed as one of the
+props to your `<Board>` component. Adapting our previous example, we could add
+a call to `step` each time the human player clicks on a cell:
+
+```js
+class TicTacToeBoard extends React.Component {
+  onClick(id) {
+    if (this.isActive(id)) {
+      this.props.moves.clickCell(id);
+      this.props.events.endTurn();
+      +setTimeout(() => this.props.step(), 1000);
+    }
+  }
+
+  // ...
+}
+```
+
+We’re missing some checks to make sure the `clickCell` move was valid
+before activating the bot or to prevent multiple timeouts if the player
+clicks several times, but this demonstrates a basic use of `step`.
+A better API for AI-enabled games will be added as the framework develops.
+
 The framework will come bundled with a few different bot algorithms, and an advanced
 version of MCTS that will allow you to specify a set of objectives to optimize for.
 For example, at any given point in the game you can tell the bot to gather resources


### PR DESCRIPTION
This tries to improve the documentation around AI/bots following @julienroulle’s questions on Gitter. In the process I’ve also tidied up some small things I came across.

I’m not sure if some of this was deliberately undocumented while waiting for #383 — i.e. not explicitly advising how to call `step` from the client — but it  seemed like it might be worth adding for now.

I think [this is the CodeSandbox referenced](https://codesandbox.io/s/boardgameio-5lbe5) on Gitter, but I suspect it was not intended to have auto-stepping AI included in any case.