### PR TITLE
Enable a function to be used for objective weights in MCTS bot

### DIFF
--- a/src/ai/bot.js
+++ b/src/ai/bot.js
@@ -236,7 +236,11 @@ export class MCTSBot extends Bot {
       const score = Object.keys(objectives).reduce((score, key) => {
         const objective = objectives[key];
         if (objective.checker(G, ctx)) {
-          return score + objective.weight;
+          if (typeof objective.weight === 'number') {
+            return score + objective.weight;
+          } else {
+            return score + objective.weight(G, ctx);
+          }
         }
         return score;
       }, 0.0);

--- a/src/ai/bot.test.js
+++ b/src/ai/bot.test.js
@@ -282,6 +282,31 @@ describe('MCTSBot', () => {
     }
   });
 
+  test('objectivesWithWeightFunction', () => {
+    const objectives = () => ({
+      'play-on-square-0': {
+        checker: G => G.cells[0] !== null,
+        weight: () => 10.0,
+      },
+    });
+
+    const state = InitializeGame({ game: TicTacToe });
+
+    for (let i = 0; i < 10; i++) {
+      const bot = new MCTSBot({
+        iterations: 200,
+        seed: i,
+        game: TicTacToe,
+        enumerate,
+        objectives,
+        playerID: '0',
+      });
+
+      const { action } = bot.play(state, '0');
+      expect(action.payload.args).toEqual([0]);
+    }
+  });
+
   test('iterations & playout depth settings', () => {
     const state = InitializeGame({ game: TicTacToe });
 


### PR DESCRIPTION
Objectives that can return their weight based on the game state are much more useful than those with fixed weights (a simple example is an objective for maximising the player's score in games that have a score)

Example usage:

```
const objectives = () => ({
    'score': {
        checker: () => true,
        weight: (G, ctx) => (G.scores[parseInt(ctx.currentPlayer)])
    }
});
```

#### Checklist

* [X] Use a separate branch in your local repo (not `master`).
* [X] Test coverage is 100% (or you have a story for why it's ok).
