### PR TITLE
Fix playerID passed to events called from hooks

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -32,6 +32,8 @@ export class Events {
       };
     }
 
+    events._setPlayerID = playerID => (this.playerID = playerID);
+
     return { ...ctx, events };
   }
 

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -308,7 +308,6 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
 
     // Initialize the turn order state.
     if (currentPlayer) {
-      if (ctx.events) ctx.events._setPlayerID(currentPlayer);
       ctx = { ...ctx, currentPlayer };
       if (conf.turn.activePlayers) {
         ctx = SetActivePlayers(ctx, ctx.currentPlayer, conf.turn.activePlayers);
@@ -318,6 +317,8 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       // when there is no currentPlayer yet.
       ctx = InitTurnOrderState(G, ctx, conf.turn);
     }
+
+    if (ctx.events) ctx.events._setPlayerID(ctx.currentPlayer);
 
     G = conf.turn.onBegin(G, ctx);
 

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -523,6 +523,8 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
       return state;
     }
 
+    if (ctx.events) ctx.events._setPlayerID(ctx.currentPlayer);
+
     // Run turn-end triggers.
     G = conf.turn.onEnd(G, ctx);
 

--- a/src/core/flow.js
+++ b/src/core/flow.js
@@ -308,6 +308,7 @@ export function Flow({ moves, phases, endIf, turn, events, plugins }) {
 
     // Initialize the turn order state.
     if (currentPlayer) {
+      if (ctx.events) ctx.events._setPlayerID(currentPlayer);
       ctx = { ...ctx, currentPlayer };
       if (conf.turn.activePlayers) {
         ctx = SetActivePlayers(ctx, ctx.currentPlayer, conf.turn.activePlayers);

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -902,4 +902,81 @@ describe('activePlayers', () => {
       '2': 'B',
     });
   });
+
+  test('setActivePlayers in turn.onBegin works', () => {
+    const game = {
+      turn: {
+        onBegin: (G, ctx) => {
+          console.log('turn.onBegin', ctx.currentPlayer);
+          ctx.events.setActivePlayers({ player: 'A', others: 'B' });
+        },
+        stages: { A: {}, B: {} },
+      },
+    };
+
+    const client = Client({ game, numPlayers: 3 });
+
+    expect(client.getState().ctx.currentPlayer).toBe('0');
+    expect(client.getState().ctx.activePlayers).toEqual({
+      '0': 'A',
+      '1': 'B',
+      '2': 'B',
+    });
+
+    console.log('end turn');
+    client.events.endTurn();
+
+    expect(client.getState().ctx.currentPlayer).toBe('1');
+    expect(client.getState().ctx.activePlayers).toEqual({
+      '0': 'B',
+      '1': 'A',
+      '2': 'B',
+    });
+
+    console.log('end turn');
+    client.events.endTurn();
+
+    expect(client.getState().ctx.currentPlayer).toBe('2');
+  });
+
+  test('setActivePlayers in phase.onBegin works', () => {
+    const game = {
+      phases: {
+        first: {
+          start: true,
+          onBegin: (G, ctx) => {
+            ctx.events.setActivePlayers({ player: 'A', others: 'B' });
+          },
+        },
+        second: {
+          onBegin: (G, ctx) => {
+            ctx.events.setActivePlayers({ player: 'B', others: 'A' });
+          },
+          turn: {
+            stages: { A: {}, B: {} },
+          },
+        },
+      },
+    };
+
+    const client = Client({ game, numPlayers: 3 });
+
+    expect(client.getState().ctx.currentPlayer).toBe('0');
+    expect(client.getState().ctx.phase).toBe('first');
+    expect(client.getState().ctx.activePlayers).toEqual({
+      '0': 'A',
+      '1': 'B',
+      '2': 'B',
+    });
+
+    client.events.setPhase('second');
+
+    expect(client.getState().ctx.currentPlayer).toBe('0');
+    expect(client.getState().ctx.phase).toBe('second');
+    expect(client.getState().ctx.activePlayers).toEqual({
+      '0': 'B',
+      '1': 'A',
+      '2': 'A',
+    });
+  });
 });

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -969,7 +969,6 @@ describe('activePlayers', () => {
     const game = {
       turn: {
         onBegin: (G, ctx) => {
-          console.log('turn.onBegin', ctx.currentPlayer);
           ctx.events.setActivePlayers({ player: 'A', others: 'B' });
         },
         stages: { A: {}, B: {} },
@@ -985,7 +984,6 @@ describe('activePlayers', () => {
       '2': 'B',
     });
 
-    console.log('end turn');
     client.events.endTurn();
 
     expect(client.getState().ctx.currentPlayer).toBe('1');
@@ -995,7 +993,6 @@ describe('activePlayers', () => {
       '2': 'B',
     });
 
-    console.log('end turn');
     client.events.endTurn();
 
     expect(client.getState().ctx.currentPlayer).toBe('2');

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -1030,11 +1030,11 @@ describe('activePlayers', () => {
 
     client.events.setPhase('second');
 
-    expect(client.getState().ctx.currentPlayer).toBe('0');
+    expect(client.getState().ctx.currentPlayer).toBe('1');
     expect(client.getState().ctx.phase).toBe('second');
     expect(client.getState().ctx.activePlayers).toEqual({
-      '0': 'B',
-      '1': 'A',
+      '0': 'A',
+      '1': 'B',
       '2': 'A',
     });
   });

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -276,6 +276,8 @@ export function UpdateTurnOrderState(G, ctx, turn, endTurnArg) {
     }
   }
 
+  if (ctx.events) ctx.events._setPlayerID(currentPlayer);
+
   ctx = {
     ...ctx,
     playOrderPos,

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -276,8 +276,6 @@ export function UpdateTurnOrderState(G, ctx, turn, endTurnArg) {
     }
   }
 
-  if (ctx.events) ctx.events._setPlayerID(currentPlayer);
-
   ctx = {
     ...ctx,
     playOrderPos,


### PR DESCRIPTION
~This is not complete yet and I’m not sure to what extent this makes sense, but~ this is in response to #487.

I added tests for using `events.setActivePlayers` in `onBegin` hooks. Phase `onBegin` hooks appeared to be working as expected, but turn `onBegin` hooks weren’t. I have added a change that fixes the turn hooks: `StartTurn` calls into the `Events` instance to update its internal `playerID` to the new current player.

**N.B.** Events called in hooks still suffer from the bug described in #482 if the turn or phase was ended from a move.

#### Checklist

* [X] Use a separate branch in your local repo (not `master`).
* [X] Test coverage is 100% (or you have a story for why it's ok).
