### PR TITLE
Increment current player at start of phase in TurnOrder.DEFAULT

### DIFF
--- a/docs/documentation/turn-order.md
+++ b/docs/documentation/turn-order.md
@@ -63,9 +63,15 @@ specify any turn order.
 
 ##### RESET
 
-This is similar to `DEFAULT`, but instead of continuing
-from the previous position at the beginning of a phase, it
+This is similar to `DEFAULT`, but instead of incrementing
+the previous position at the beginning of a phase, it
 will always start from `0`.
+
+##### CONTINUE
+
+This is also similar to `DEFAULT`, but instead of incrementing
+the previous position at the beginning of a phase, it will
+start with the player who ended the previous phase.
 
 ##### ONCE
 

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -137,7 +137,7 @@ describe('phases', () => {
     expect(state.ctx.phase).toBe(null);
   });
 
-  test('maintain playOrderPos on phase end', () => {
+  test('increment playOrderPos on phase end', () => {
     const flow = Flow({
       phases: { A: { start: true, next: 'B' }, B: { next: 'A' } },
     });
@@ -148,7 +148,7 @@ describe('phases', () => {
     state = flow.processEvent(state, gameEvent('endTurn'));
     expect(state.ctx.playOrderPos).toBe(1);
     state = flow.processEvent(state, gameEvent('endPhase'));
-    expect(state.ctx.playOrderPos).toBe(1);
+    expect(state.ctx.playOrderPos).toBe(2);
   });
 
   describe('setPhase', () => {
@@ -282,10 +282,11 @@ describe('turn', () => {
 
       expect(state.ctx.phase).toBe('B');
       expect(state.ctx.turn).toBe(3);
-      expect(state.ctx.currentPlayer).toBe('1');
+      expect(state.ctx.currentPlayer).toBe('0');
 
-      state = flow.processMove(state, makeMove('move', null, '1').payload);
+      state = flow.processMove(state, makeMove('move', null, '0').payload);
       expect(state.ctx.turn).toBe(4);
+      expect(state.ctx.currentPlayer).toBe('1');
     });
   });
 
@@ -364,7 +365,7 @@ describe('turn', () => {
     state = flow.processMove(state, makeMove().payload);
 
     expect(state.ctx.phase).toBe('B');
-    expect(state.ctx.currentPlayer).toBe('1');
+    expect(state.ctx.currentPlayer).toBe('0');
     expect(state.ctx.turn).toBe(3);
   });
 });

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -332,6 +332,16 @@ export const TurnOrder = {
   },
 
   /**
+   * CONTINUE
+   *
+   * Similar to DEFAULT, but starts with the player who ended the last phase.
+   */
+  CONTINUE: {
+    first: (G, ctx) => ctx.playOrderPos,
+    next: (G, ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
+  },
+
+  /**
    * ONCE
    *
    * Another round-robin turn order, but goes around just once.

--- a/src/core/turn-order.js
+++ b/src/core/turn-order.js
@@ -314,7 +314,10 @@ export const TurnOrder = {
    * The default round-robin turn order.
    */
   DEFAULT: {
-    first: (G, ctx) => ctx.playOrderPos,
+    first: (G, ctx) =>
+      ctx.turn === 0
+        ? ctx.playOrderPos
+        : (ctx.playOrderPos + 1) % ctx.playOrder.length,
     next: (G, ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
   },
 

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -66,7 +66,7 @@ describe('turn orders', () => {
     expect(state.ctx.currentPlayer).toBe('1');
     expect(state.ctx.phase).toBe('A');
     state = flow.processEvent(state, gameEvent('endPhase'));
-    expect(state.ctx.currentPlayer).toBe('1');
+    expect(state.ctx.currentPlayer).toBe('0');
     expect(state.ctx.phase).toBe('B');
   });
 

--- a/src/core/turn-order.test.js
+++ b/src/core/turn-order.test.js
@@ -70,6 +70,29 @@ describe('turn orders', () => {
     expect(state.ctx.phase).toBe('B');
   });
 
+  test('CONTINUE', () => {
+    const flow = Flow({
+      turn: { order: TurnOrder.CONTINUE },
+      phases: { A: { start: true, next: 'B' }, B: {} },
+    });
+
+    let state = { ctx: flow.ctx(2) };
+    state = flow.init(state);
+    expect(state.ctx.currentPlayer).toBe('0');
+    expect(state.ctx).not.toHaveUndefinedProperties();
+
+    state = flow.processEvent(state, gameEvent('endTurn'));
+    expect(state.ctx.currentPlayer).toBe('1');
+    state = flow.processEvent(state, gameEvent('endTurn'));
+    expect(state.ctx.currentPlayer).toBe('0');
+    state = flow.processEvent(state, gameEvent('endTurn'));
+    expect(state.ctx.currentPlayer).toBe('1');
+    expect(state.ctx.phase).toBe('A');
+    state = flow.processEvent(state, gameEvent('endPhase'));
+    expect(state.ctx.currentPlayer).toBe('1');
+    expect(state.ctx.phase).toBe('B');
+  });
+
   test('RESET', () => {
     const flow = Flow({
       turn: { order: TurnOrder.RESET },


### PR DESCRIPTION
This would close #517 


### Changes

1. `TurnOrder.DEFAULT` will now increment the current player at the start of a phase and includes a check to prevent incrementing if the phase is a game’s starting phase.

2. Adds `TurnOrder.CONTINUE` to provide the old default behaviour for those who need it. Is this a good name? I couldn’t think of anything clearer that would still be concise.


### Breaking Changes

This change will break current behaviour for anyone:

- Using v0.33 or higher, AND
- Using phases, AND
- Using `TurnOrder.DEFAULT` directly or not setting a custom `turn.order.first`

#### Migration

If currently using the default turn order directly, use `TurnOrder.CONTINUE` instead:

```diff
import { TurnOrder } from 'boardgame.io/core'

const turn = {
- order: TurnOrder.DEFAULT,
+ order: TurnOrder.CONTINUE,
}
```

If currently not setting a turn order (and using phases), import `TurnOrder`:

```diff
+ import { TurnOrder } from 'boardgame.io/core'

const turn = {
+ order: TurnOrder.CONTINUE,
}
```