### PR TITLE
Fix events in hooks triggered by a move

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -40,8 +40,7 @@ export class Events {
    * @param {object} state - The state object { G, ctx }.
    */
   update(state) {
-    const length = this.dispatch.length;
-    for (let i = 0; i < length; i++) {
+    for (let i = 0; i < this.dispatch.length; i++) {
       const item = this.dispatch[i];
 
       // If the turn already ended some other way,

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -958,7 +958,7 @@ describe('infinite loops', () => {
         },
       },
       turn: {
-        endif: () => true,
+        endIf: () => true,
       },
     };
     const client = Client({ game });

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -932,6 +932,40 @@ describe('infinite loops', () => {
     client.events.endPhase();
     expect(client.getState().ctx.phase).toBe('B');
   });
+
+  test('loop 3', () => {
+    const game = {
+      moves: {
+        endTurn: (G, ctx) => {
+          ctx.events.endTurn();
+        },
+      },
+      turn: {
+        onBegin: (G, ctx) => ctx.events.endTurn(),
+      },
+    };
+    const client = Client({ game });
+    expect(client.getState().ctx.currentPlayer).toBe('0');
+    client.moves.endTurn();
+    expect(client.getState().ctx.currentPlayer).toBe('1');
+  });
+
+  test('loop 4', () => {
+    const game = {
+      moves: {
+        endTurn: (G, ctx) => {
+          ctx.events.endTurn();
+        },
+      },
+      turn: {
+        endif: () => true,
+      },
+    };
+    const client = Client({ game });
+    expect(client.getState().ctx.currentPlayer).toBe('0');
+    client.moves.endTurn();
+    expect(client.getState().ctx.currentPlayer).toBe('1');
+  });
 });
 
 describe('activePlayers', () => {

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -965,3 +965,32 @@ describe('activePlayers', () => {
     });
   });
 });
+
+test('events in hooks triggered by moves should be processed', () => {
+  const game = {
+    turn: {
+      onBegin: (G, ctx) => {
+        ctx.events.setActivePlayers({ currentPlayer: 'A' });
+      },
+    },
+    moves: {
+      endTurn: (G, ctx) => {
+        ctx.events.endTurn();
+      },
+    },
+  };
+
+  const client = Client({ game, numPlayers: 3 });
+
+  expect(client.getState().ctx.currentPlayer).toBe('0');
+  expect(client.getState().ctx.activePlayers).toEqual({
+    '0': 'A',
+  });
+
+  client.moves.endTurn();
+
+  expect(client.getState().ctx.currentPlayer).toBe('1');
+  expect(client.getState().ctx.activePlayers).toEqual({
+    '1': 'A',
+  });
+});


### PR DESCRIPTION
Closes #482
Closes #487

The `update` method of the `Events` class currently caches the length of the event dispatch queue before processing it, avoiding processing of any new events pushed during processing.

https://github.com/nicolodavis/boardgame.io/blob/e20aca433f758ab66eaabbd077f61cebc25a9575/src/core/events.js#L42-L44

This seems sensible as it limits the scope of `update ` and presumably guards against infinite loops. However, this also causes the bug that events triggered _after_ a move, i.e. in hooks, are never processed and discarded.

This PR adds a test for the expected behaviour and simply removes the caching of the queue length, meaning now those new events are handled correctly. All tests are passing, but if you think there’s a risk making this change, let me know.

---

**Edit:** Just noticed [the commit that added the length caching](https://github.com/nicolodavis/boardgame.io/commit/39c00e41690f0d40c4b3f5ac47213f023ff53f6d) was labelled “remove infinite loop”, but the infinite loop tests seem to be passing, so maybe something else is now preventing infinite loops?