### PR TITLE
refactor(client): Scope global CSS selectors in Debug panel

### DIFF
--- a/src/client/debug/Debug.svelte
+++ b/src/client/debug/Debug.svelte
@@ -74,7 +74,7 @@
     background: #fefefe;
   }
 
-  :global(button, select) {
+  .debug-panel :global(button, select) {
     cursor: pointer;
     outline: none;
     background: #eee;
@@ -84,21 +84,21 @@
     border-radius: 3px;
   }
 
-  :global(button) {
+  .debug-panel :global(button) {
     padding-left: 10px;
     padding-right: 10px;
   }
 
-  :global(button:hover) {
+  .debug-panel :global(button:hover) {
     background: #ddd;
   }
 
-  :global(button:active) {
+  .debug-panel :global(button:active) {
     background: #888;
     color: #fff;
   }
 
-  :global(section) {
+  .debug-panel :global(section) {
     margin-bottom: 20px;
   }
 </style>


### PR DESCRIPTION
Currently `<button>`, `<section>`, and `<select>` elements in the Debug panel are being styled directly with global scope. This poses a fairly high risk of leaking styles to elements in the rest of an app using the debug panel.

This PR restricts the scope of those global selectors to only apply to children of the root debug panel component.