### PR TITLE
fix(server): Use namespaced ID to delete persisted game data

### DIFF
--- a/src/server/api.test.js
+++ b/src/server/api.test.js
@@ -523,9 +523,7 @@ describe('.createApiServer', () => {
               response = await request(app.callback())
                 .post('/games/foo/1/leave')
                 .send('playerID=0&credentials=SECRET1');
-              expect(setSpy).toHaveBeenCalledWith(
-                expect.stringMatching(':1')
-              );
+              expect(setSpy).toHaveBeenCalledWith(expect.stringMatching(':1'));
               expect(setSpy).toHaveBeenCalledWith(
                 expect.stringMatching(':metadata')
               );

--- a/src/server/api.test.js
+++ b/src/server/api.test.js
@@ -523,7 +523,9 @@ describe('.createApiServer', () => {
               response = await request(app.callback())
                 .post('/games/foo/1/leave')
                 .send('playerID=0&credentials=SECRET1');
-              expect(setSpy).toHaveBeenCalledWith('1');
+              expect(setSpy).toHaveBeenCalledWith(
+                expect.stringMatching(':1')
+              );
               expect(setSpy).toHaveBeenCalledWith(
                 expect.stringMatching(':metadata')
               );

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -205,7 +205,7 @@ export const addApiToServer = ({ app, db, games, lobbyConfig }) => {
       await db.set(GameMetadataKey(namespacedGameID), gameMetadata);
     } else {
       // remove room
-      await db.remove(roomID);
+      await db.remove(namespacedGameID);
       await db.remove(GameMetadataKey(namespacedGameID));
     }
     ctx.body = {};


### PR DESCRIPTION
The intended behaviour of the server is to delete persisted game data when all players leave the game. When deleting the game data, the database implementation is currently passed the wrong ID, so the game data is never deleted, only the metadata. This PR fixes this bug.