### PR TITLE
refactor: Harmonise Master’s auth signature with authenticateCredentials

### DIFF
--- a/src/master/master.js
+++ b/src/master/master.js
@@ -68,8 +68,9 @@ export const doesGameRequireAuthentication = gameMetadata => {
  * Verifies that the move came from a player with the correct credentials.
  */
 export const isActionFromAuthenticPlayer = (credentials, playerMetadata) => {
-  if (credentials && credentials === playerMetadata.credentials) return true;
-  return false;
+  if (!credentials) return false;
+  if (!playerMetadata) return false;
+  return credentials === playerMetadata.credentials;
 };
 
 /**

--- a/src/master/master.js
+++ b/src/master/master.js
@@ -15,7 +15,7 @@ import * as logging from '../core/logger';
 
 const GameMetadataKey = gameID => `${gameID}:metadata`;
 
-const getPlayerMetadata = (gameMetadata, playerID) => {
+export const getPlayerMetadata = (gameMetadata, playerID) => {
   if (!gameMetadata || !gameMetadata.players) return;
   return gameMetadata.players[playerID];
 };

--- a/src/master/master.js
+++ b/src/master/master.js
@@ -86,11 +86,13 @@ export class Master {
     this.storageAPI = storageAPI;
     this.transportAPI = transportAPI;
     this.auth = () => true;
+    this.shouldAuth = doesGameRequireAuthentication;
 
     if (auth === true) {
       this.auth = isActionFromAuthenticPlayer;
     } else if (typeof auth === 'function') {
       this.auth = auth;
+      this.shouldAuth = () => true;
     }
   }
 

--- a/src/master/master.js
+++ b/src/master/master.js
@@ -15,6 +15,11 @@ import * as logging from '../core/logger';
 
 const GameMetadataKey = gameID => `${gameID}:metadata`;
 
+const getPlayerMetadata = (gameMetadata, playerID) => {
+  if (!gameMetadata || !gameMetadata.players) return;
+  return gameMetadata.players[playerID];
+};
+
 /**
  * Redact the log.
  *
@@ -106,13 +111,15 @@ export class Master {
     const { credentials } = action.payload || {};
     if (this.executeSynchronously) {
       const gameMetadata = this.storageAPI.get(GameMetadataKey(gameID));
-      isActionAuthentic = doesGameRequireAuthentication(gameMetadata)
-        ? this.auth(credentials, gameMetadata.players[playerID])
+      const playerMetadata = getPlayerMetadata(gameMetadata, playerID);
+      isActionAuthentic = this.shouldAuth(gameMetadata)
+        ? this.auth(credentials, playerMetadata)
         : true;
     } else {
       const gameMetadata = await this.storageAPI.get(GameMetadataKey(gameID));
-      isActionAuthentic = doesGameRequireAuthentication(gameMetadata)
-        ? await this.auth(credentials, gameMetadata.players[playerID])
+      const playerMetadata = getPlayerMetadata(gameMetadata, playerID);
+      isActionAuthentic = this.shouldAuth(gameMetadata)
+        ? await this.auth(credentials, playerMetadata)
         : true;
     }
     if (!isActionAuthentic) {

--- a/src/master/master.js
+++ b/src/master/master.js
@@ -73,10 +73,13 @@ export const doesGameRequireAuthentication = gameMetadata => {
 /**
  * Verifies that the move came from a player with the correct credentials.
  */
-export const isActionFromAuthenticPlayer = (credentials, playerMetadata) => {
-  if (!credentials) return false;
+export const isActionFromAuthenticPlayer = (
+  actionCredentials,
+  playerMetadata
+) => {
+  if (!actionCredentials) return false;
   if (!playerMetadata) return false;
-  return credentials === playerMetadata.credentials;
+  return actionCredentials === playerMetadata.credentials;
 };
 
 /**

--- a/src/master/master.js
+++ b/src/master/master.js
@@ -16,8 +16,9 @@ import * as logging from '../core/logger';
 const GameMetadataKey = gameID => `${gameID}:metadata`;
 
 export const getPlayerMetadata = (gameMetadata, playerID) => {
-  if (!gameMetadata || !gameMetadata.players) return;
-  return gameMetadata.players[playerID];
+  if (gameMetadata && gameMetadata.players) {
+    return gameMetadata.players[playerID];
+  }
 };
 
 /**

--- a/src/master/master.js
+++ b/src/master/master.js
@@ -95,10 +95,11 @@ export class Master {
     this.storageAPI = storageAPI;
     this.transportAPI = transportAPI;
     this.auth = () => true;
-    this.shouldAuth = doesGameRequireAuthentication;
+    this.shouldAuth = () => false;
 
     if (auth === true) {
       this.auth = isActionFromAuthenticPlayer;
+      this.shouldAuth = doesGameRequireAuthentication;
     } else if (typeof auth === 'function') {
       this.auth = auth;
       this.shouldAuth = () => true;

--- a/src/master/master.test.js
+++ b/src/master/master.test.js
@@ -264,16 +264,10 @@ describe('authentication', () => {
   const sendAll = jest.fn();
   const game = { seed: 0 };
   const gameID = 'gameID';
-  const gameMetadata = {
-    players: {
-      '0': { credentials: 'SECRET' },
-    },
-  };
   const action = ActionCreators.gameEvent('endTurn');
   const storage = new InMemory();
 
   beforeAll(async () => {
-    storage.set(`${gameID}:metadata`, gameMetadata);
     const master = new Master(game, storage, TransportAPI());
     await master.onSync(gameID, '0');
   });

--- a/src/master/master.test.js
+++ b/src/master/master.test.js
@@ -11,6 +11,7 @@ import { InMemory } from '../server/db/inmemory';
 import {
   Master,
   redactLog,
+  getPlayerMetadata,
   doesGameRequireAuthentication,
   isActionFromAuthenticPlayer,
 } from './master';
@@ -426,6 +427,37 @@ describe('redactLog', () => {
   });
 });
 
+describe('getPlayerMetadata', () => {
+  describe('when metadata is not found', () => {
+    test('then playerMetadata is undefined', () => {
+      expect(getPlayerMetadata(undefined, '0')).toBeUndefined();
+    });
+  });
+
+  describe('when metadata does not contain players field', () => {
+    test('then playerMetadata is undefined', () => {
+      expect(getPlayerMetadata({}, '0')).toBeUndefined();
+    });
+  });
+
+  describe('when metadata does not contain playerID', () => {
+    test('then playerMetadata is undefined', () => {
+      expect(getPlayerMetadata({ players: { '1': {} } }, '0')).toBeUndefined();
+    });
+  });
+
+  describe('when metadata contains playerID', () => {
+    test('then playerMetadata is returned', () => {
+      const playerMetadata = { credentials: 'SECRET' };
+      const result = getPlayerMetadata(
+        { players: { '0': playerMetadata } },
+        '0'
+      );
+      expect(result).toBe(playerMetadata);
+    });
+  });
+});
+
 describe('doesGameRequireAuthentication', () => {
   describe('when game metadata is not found', () => {
     test('then authentication is not required', () => {
@@ -521,6 +553,13 @@ describe('isActionFromAuthenticPlayer', () => {
       });
       test('then action is not authentic', async () => {
         const result = isActionFromAuthenticPlayer(credentials, playerMetadata);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('when playerMetadata is not found', () => {
+      test('then action is not authentic', () => {
+        const result = isActionFromAuthenticPlayer(credentials);
         expect(result).toBe(false);
       });
     });

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -6,7 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { Server, createServerRunConfig } from '.';
+import { Server, createServerRunConfig, wrapAuthFn } from '.';
 import * as api from './api';
 
 const game = { seed: 0 };
@@ -205,4 +205,23 @@ describe('createServerRunConfig', () => {
       },
     });
   });
+});
+
+describe('wrapAuthFn', () => {
+  test('calls wrapped function with expected arguments', () => {
+    const spy = jest.fn()
+    const fn = wrapAuthFn(spy)
+    const credentials = '123456'
+    const playerMetadata = { credentials }
+    fn({
+       action: {
+         payload: { credentials },
+       },
+       gameMetadata: {
+         '0': playerMetadata,
+       },
+       playerID: '0',
+    })
+    expect(spy).toHaveBeenCalledWith(credentials, playerMetadata)
+  })
 });

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -6,7 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { Server, createServerRunConfig, wrapAuthFn } from '.';
+import { Server, createServerRunConfig } from '.';
 import * as api from './api';
 
 const game = { seed: 0 };
@@ -205,23 +205,4 @@ describe('createServerRunConfig', () => {
       },
     });
   });
-});
-
-describe('wrapAuthFn', () => {
-  test('calls wrapped function with expected arguments', () => {
-    const spy = jest.fn()
-    const fn = wrapAuthFn(spy)
-    const credentials = '123456'
-    const playerMetadata = { credentials }
-    fn({
-       action: {
-         payload: { credentials },
-       },
-       gameMetadata: {
-         '0': playerMetadata,
-       },
-       playerID: '0',
-    })
-    expect(spy).toHaveBeenCalledWith(credentials, playerMetadata)
-  })
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -34,14 +34,6 @@ export const createServerRunConfig = (portOrConfig?: any, callback?: any) => {
 };
 
 /**
- * Wrap a user-provided auth function to simplify external API
- * @param  {function} fn The authentication function to wrap
- * @return {function} Wrapped function for use by master
- */
-export const wrapAuthFn = fn => ({ action, gameMetadata, playerID }) =>
-  fn(action.payload.credentials, gameMetadata[playerID]);
-
-/**
  * Instantiate a game server.
  *
  * @param {Array} games - The games that this server will handle.
@@ -71,7 +63,7 @@ export function Server({
   if (transport === undefined) {
     const auth =
       typeof authenticateCredentials === 'function'
-        ? wrapAuthFn(authenticateCredentials)
+        ? authenticateCredentials
         : true;
     transport = SocketIO({ auth });
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -38,7 +38,7 @@ export const createServerRunConfig = (portOrConfig?: any, callback?: any) => {
  * @param  {function} fn The authentication function to wrap
  * @return {function} Wrapped function for use by master
  */
-const wrapAuthFn = fn => ({ action, gameMetadata, playerID }) =>
+export const wrapAuthFn = fn => ({ action, gameMetadata, playerID }) =>
   fn(action.payload.credentials, gameMetadata[playerID]);
 
 /**


### PR DESCRIPTION
Following on from #532, this adds a test for the wrapper used around users’ `authenticateCredentials` methods.