### PR TITLE
fix(plugins): Fix PluginPlayer setup

### DIFF
--- a/src/plugins/plugin-player.js
+++ b/src/plugins/plugin-player.js
@@ -33,11 +33,11 @@ export default {
 
       const players = {
         ...G.players,
-        [current]: G.player,
+        [current]: 'player' in G ? G.player : G.players[current],
       };
 
       if (other !== null) {
-        players[other] = G.opponent;
+        players[other] = 'opponent' in G ? G.opponent : G.players[other];
       }
 
       {

--- a/src/plugins/plugin-player.test.js
+++ b/src/plugins/plugin-player.test.js
@@ -100,3 +100,32 @@ describe('3 player game', () => {
     });
   });
 });
+
+describe('game with phases', () => {
+  let client;
+
+  beforeAll(() => {
+    const game = {
+      playerSetup: id => ({ id }),
+      plugins: [PluginPlayer],
+      phases: {
+        phase: {},
+      },
+    };
+
+    client = Client({ game });
+  });
+
+  test('includes playerSetup state', () => {
+    expect(client.getState().G).toEqual({
+      players: {
+        0: {
+          id: '0',
+        },
+        1: {
+          id: '1',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
This closes #530 and follows from some [discussion on Gitter](https://gitter.im/boardgame-io/General?at=5e409fefb612cc7bb1593457).

#### Bug

When the game definition included a `phases` section, the state expected from the PluginPlayer’s setup method was being overwritten with `undefined`.

#### Diagnosis

The player plugin wraps moves with a modified `G`, adding a `player` and (for 2-player games) `opponent` field from `G.players`, then restores their values to `G.players` after the move.

For some reason, [the `turn.onBegin` function called in `StartTurn`](https://github.com/nicolodavis/boardgame.io/blob/b0a5175eb6a7a3656623a6ced640a9c6c3a741ef/src/core/flow.js#L324) is wrapped _twice_. I still don’t quite understand why, or why this only happens when phases are defined, but here is the result of a `console.trace` I added to the start of the player plugin’s `moveFn`:

<details>
  <summary>Double-wrapped <code>moveFn</code> stack trace</summary>
  <pre>
    <code>
Trace: fnWrap
  at CustomConsole.trace (internal/console/constructor.js:336:11)
  at trace (/boardgame.io/src/plugins/plugin-player.js:19:15)
  at Object.onBegin (/boardgame.io/src/plugins/main.js:79:10)
  at StartTurn (/boardgame.io/src/core/flow.js:322:5)
  at Process (/boardgame.io/src/core/flow.js:222:15)
  at Object.init (/boardgame.io/src/core/flow.js:845:11)
  at init (/boardgame.io/src/core/initialize.js:64:25)
  at new _ClientImpl (/boardgame.io/src/client/client.js:111:22)
  at Client (/boardgame.io/src/client/client.js:431:10)
  at Object.&lt;anonymous&gt; (/boardgame.io/src/plugins/plugin-player.test.js:116:14)
Trace: fnWrap
  at CustomConsole.trace (internal/console/constructor.js:336:11)
  at trace (/boardgame.io/src/plugins/plugin-player.js:19:15)
  at Proxy.&lt;anonymous&gt; (/boardgame.io/src/plugins/main.js:79:10)
  at Proxy.&lt;anonymous&gt; (/boardgame.io/node_modules/immer/src/immer.js:44:45)
  at Immer.call (/boardgame.io/node_modules/immer/src/immer.js:64:33)
  at produce (/boardgame.io/node_modules/immer/src/immer.js:44:22)
  at /boardgame.io/src/plugins/plugin-player.js:33:17
  at Object.onBegin (/boardgame.io/src/plugins/main.js:79:10)
  at StartTurn (/boardgame.io/src/core/flow.js:322:5)
  at Process (/boardgame.io/src/core/flow.js:222:15)
    </code>
  </pre>
</details>

Because the wrapper is doubled, after the move function returns to the outer `fnWrap`, the `G.player` and `G.opponent` fields have already been stripped and when they are restored to `G.players` they are undefined.

#### Fix

I’ve added checks to the plugin’s `fnWrap` to make sure that `G.player` and `G.opponent` are defined before restoring them to `G.players`.

Presumably the double wrapping is a more fundamental bug that needs fixing, because it could impact similar plugins, but I’m not sure exactly where that’s coming from.