### PR TITLE
fix local multiplayer test example

### DIFF
--- a/docs/documentation/testing.md
+++ b/docs/documentation/testing.md
@@ -93,8 +93,8 @@ it('multiplayer test', () => {
   const p0 = Client({ ...spec, playerID: '0' });
   const p1 = Client({ ...spec, playerID: '1' });
 
-  p0.connect();
-  p1.connect();
+  p0.start();
+  p1.start();
 
   p0.moves.moveA();
   p0.events.endTurn();


### PR DESCRIPTION
.connect() has been renamed to .start() in 2f86d92