### PR TITLE
Add missing import in multiplayer documentation

### DIFF
--- a/docs/documentation/multiplayer.md
+++ b/docs/documentation/multiplayer.md
@@ -39,6 +39,7 @@ playing in the same game.
 ```js
 // src/App.js
 
+import React from 'react';
 import { Client } from 'boardgame.io/react';
 import { Local } from 'boardgame.io/multiplayer';
 import { TicTacToe } from './game';


### PR DESCRIPTION
Add `import React from 'react';` 
needed to avoid `'React' must be in scope when using JSX  react/react-in-jsx-scope` error.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
