### PR TITLE
fix(master): Remove credentials from action payloads after use

### DIFF
--- a/src/master/master.js
+++ b/src/master/master.js
@@ -83,6 +83,18 @@ export const isActionFromAuthenticPlayer = (
 };
 
 /**
+ * Remove player credentials from action payload
+ */
+const stripCredentialsFromAction = action => {
+  if ('payload' in action && 'credentials' in action.payload) {
+    // eslint-disable-next-line no-unused-vars
+    const { credentials, ...payload } = action.payload;
+    action = { ...action, payload };
+  }
+  return action;
+};
+
+/**
  * Master
  *
  * Class that runs the game and maintains the authoritative state.
@@ -135,6 +147,8 @@ export class Master {
     if (!isActionAuthentic) {
       return { error: 'unauthorized action' };
     }
+
+    action = stripCredentialsFromAction(action);
 
     const key = gameID;
 


### PR DESCRIPTION
Credentials are only used to check if an action is authorized in the master and should not then be passed on to the reducer etc.

This contributes towards #227, because now credentials should not leak beyond the `Master.onUpdate` method and won’t end up for example in the game log.