### PR TITLE
feat(server): Type fetch so that it returns what the opts request

### DIFF
--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -207,7 +207,7 @@ export class Master {
     const key = gameID;
 
     let state: State;
-    let result: StorageAPI.FetchResult;
+    let result: StorageAPI.FetchResult<{ state: true }>;
     if (IsSynchronous(this.storageAPI)) {
       result = this.storageAPI.fetch(key, { state: true });
     } else {
@@ -312,7 +312,11 @@ export class Master {
     let log: LogEntry[];
     let gameMetadata: Server.GameMetadata;
     let filteredGameMetadata: { id: number; name?: string }[];
-    let result: StorageAPI.FetchResult;
+    let result: StorageAPI.FetchResult<{
+      state: true;
+      metadata: true;
+      log: true;
+    }>;
 
     if (IsSynchronous(this.storageAPI)) {
       const api = this.storageAPI as StorageAPI.Sync;

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -131,7 +131,9 @@ export const addApiToServer = ({
     const gameList = await db.listGames(gameName);
     let rooms = [];
     for (let gameID of gameList) {
-      const { metadata } = await db.fetch(gameID, { metadata: true });
+      const { metadata } = await (db as StorageAPI.Async).fetch(gameID, {
+        metadata: true,
+      });
       rooms.push({
         gameID,
         players: Object.values(metadata.players).map((player: any) => {
@@ -148,7 +150,9 @@ export const addApiToServer = ({
 
   router.get('/games/:name/:id', async ctx => {
     const gameID = ctx.params.id;
-    const { metadata } = await db.fetch(gameID, { metadata: true });
+    const { metadata } = await (db as StorageAPI.Async).fetch(gameID, {
+      metadata: true,
+    });
     if (!metadata) {
       ctx.throw(404, 'Room ' + gameID + ' not found');
     }
@@ -172,7 +176,9 @@ export const addApiToServer = ({
       ctx.throw(403, 'playerName is required');
     }
     const gameID = ctx.params.id;
-    const { metadata } = await db.fetch(gameID, { metadata: true });
+    const { metadata } = await (db as StorageAPI.Async).fetch(gameID, {
+      metadata: true,
+    });
     if (!metadata) {
       ctx.throw(404, 'Game ' + gameID + ' not found');
     }
@@ -198,7 +204,9 @@ export const addApiToServer = ({
     const gameID = ctx.params.id;
     const playerID = ctx.request.body.playerID;
     const credentials = ctx.request.body.credentials;
-    const { metadata } = await db.fetch(gameID, { metadata: true });
+    const { metadata } = await (db as StorageAPI.Async).fetch(gameID, {
+      metadata: true,
+    });
     if (typeof playerID === 'undefined' || playerID === null) {
       ctx.throw(403, 'playerID is required');
     }
@@ -229,7 +237,9 @@ export const addApiToServer = ({
     const gameID = ctx.params.id;
     const playerID = ctx.request.body.playerID;
     const credentials = ctx.request.body.credentials;
-    const { metadata } = await db.fetch(gameID, { metadata: true });
+    const { metadata } = await (db as StorageAPI.Async).fetch(gameID, {
+      metadata: true,
+    });
     // User-data to pass to the game setup function.
     const setupData = ctx.request.body.setupData;
     // The number of players for this game instance.
@@ -280,7 +290,9 @@ export const addApiToServer = ({
     const playerID = ctx.request.body.playerID;
     const credentials = ctx.request.body.credentials;
     const newName = ctx.request.body.newName;
-    const { metadata } = await db.fetch(gameID, { metadata: true });
+    const { metadata } = await (db as StorageAPI.Async).fetch(gameID, {
+      metadata: true,
+    });
     if (typeof playerID === 'undefined') {
       ctx.throw(403, 'playerID is required');
     }

--- a/src/server/db/base.ts
+++ b/src/server/db/base.ts
@@ -1,3 +1,4 @@
+import { Object } from 'ts-toolbelt';
 import { State, Server, LogEntry } from '../../types';
 
 export enum Type {
@@ -15,13 +16,21 @@ export interface FetchOpts {
 }
 
 /**
+ * Data that can be retrieved from a database fetch query
+ */
+export interface FetchFields {
+  state: State;
+  log: LogEntry[];
+  metadata: Server.GameMetadata;
+}
+
+/**
  * The result of the fetch operation.
  */
-export interface FetchResult {
-  state?: State;
-  log?: LogEntry[];
-  metadata?: Server.GameMetadata;
-}
+export type FetchResult<O extends FetchOpts> = Object.Pick<
+  FetchFields,
+  Object.SelectKeys<O, true>
+>;
 
 export interface ListGamesOpts {
   gameName?: string;
@@ -55,7 +64,10 @@ export abstract class Async {
   /**
    * Fetch the game state.
    */
-  abstract fetch(gameID: string, opts: FetchOpts): Promise<FetchResult>;
+  abstract fetch<O extends FetchOpts>(
+    gameID: string,
+    opts: O
+  ): Promise<FetchResult<O>>;
 
   /**
    * Remove the game state.
@@ -93,7 +105,7 @@ export abstract class Sync {
   /**
    * Fetch the game state.
    */
-  abstract fetch(gameID: string, opts: FetchOpts): FetchResult;
+  abstract fetch<O extends FetchOpts>(gameID: string, opts: O): FetchResult<O>;
 
   /**
    * Remove the game state.

--- a/src/server/db/flatfile.test.ts
+++ b/src/server/db/flatfile.test.ts
@@ -23,7 +23,7 @@ describe('FlatFile', () => {
 
   test('basic', async () => {
     // Must return undefined when no game exists.
-    let result = await db.fetch('gameID', { state: true });
+    const result = await db.fetch('gameID', { state: true });
     expect(result.state).toEqual(undefined);
 
     // Create game.
@@ -33,9 +33,9 @@ describe('FlatFile', () => {
     await db.setMetadata('gameID', metadata as Server.GameMetadata);
 
     // Must return created game.
-    result = await db.fetch('gameID', { state: true, metadata: true });
-    expect(result.state).toEqual({ a: 1 });
-    expect(result.metadata).toEqual({ metadata: true });
+    const result2 = await db.fetch('gameID', { state: true, metadata: true });
+    expect(result2.state).toEqual({ a: 1 });
+    expect(result2.metadata).toEqual({ metadata: true });
 
     // Must return all keys
     let keys = await db.listGames();

--- a/src/server/db/flatfile.ts
+++ b/src/server/db/flatfile.ts
@@ -50,11 +50,11 @@ export class FlatFile extends StorageAPI.Async {
     return;
   }
 
-  async fetch(
+  async fetch<O extends StorageAPI.FetchOpts>(
     gameID: string,
-    opts: StorageAPI.FetchOpts
-  ): Promise<StorageAPI.FetchResult> {
-    let result: StorageAPI.FetchResult = {};
+    opts: O
+  ): Promise<StorageAPI.FetchResult<O>> {
+    let result = {} as StorageAPI.FetchFields;
 
     if (opts.state) {
       result.state = (await this.games.getItem(gameID)) as State;
@@ -70,7 +70,7 @@ export class FlatFile extends StorageAPI.Async {
       result.log = (await this.games.getItem(key)) as LogEntry[];
     }
 
-    return result;
+    return result as StorageAPI.FetchResult<O>;
   }
 
   async clear() {

--- a/src/server/db/inmemory.ts
+++ b/src/server/db/inmemory.ts
@@ -50,8 +50,11 @@ export class InMemory extends StorageAPI.Sync {
   /**
    * Fetches state for a particular gameID.
    */
-  fetch(gameID: string, opts: StorageAPI.FetchOpts): StorageAPI.FetchResult {
-    let result: StorageAPI.FetchResult = {};
+  fetch<O extends StorageAPI.FetchOpts>(
+    gameID: string,
+    opts: O
+  ): StorageAPI.FetchResult<O> {
+    let result = {} as StorageAPI.FetchFields;
 
     if (opts.state) {
       result.state = this.games.get(gameID);
@@ -65,7 +68,7 @@ export class InMemory extends StorageAPI.Sync {
       result.log = this.log.get(gameID) || [];
     }
 
-    return result;
+    return result as StorageAPI.FetchResult<O>;
   }
 
   /**


### PR DESCRIPTION
This PR uses a generic type to model how `fetch` returns a selection of data fields based on the options object.

```ts
const data = db.fetch(gameID, { log: true });
// typeof data = { log: LogEntry[] }
```

It does add a little extra complexity in places where `let` is used before the fetch is called, but I think it might be a helpful tool.

Here’s some background: https://github.com/pirix-gh/ts-toolbelt/issues/98

---

As an aside, what is the value in maintaining async and sync APIs as separate interfaces? Can’t the in-memory database be implemented with async functions even if they are internally synchronous? It would simplify the codebase in quite a few places if it didn’t have to decide whether to `await` or not.