### PR TITLE
Typescript improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14623,10 +14623,9 @@
       }
     },
     "ts-toolbelt": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.3.5.tgz",
-      "integrity": "sha512-Xvh/gvBBCRU1qGeholaN8kgiwBH4neyun6VIDDsJf/jNwz4PXyR8ZY/5qdpB1DuMBrWMG2oTT1oWcOzGPOnluQ==",
-      "dev": true
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.3.6.tgz",
+      "integrity": "sha512-eVzym+LyQodOCfyVyQDQ6FGYbO2Xf9Nc4dGLRKlKSUpAs+8qQWHG+grDiA3ciEuNPNZ0qJnNIYkdqBW1rCWuUA=="
     },
     "ts-transformer-imports": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "svelte": "^3.12.1",
     "svelte-icons": "^1.1.0",
     "ts-jest": "^24.0.2",
-    "ts-toolbelt": "^6.3.5",
     "ts-transformer-imports": "^0.4.3",
     "ttypescript": "^1.5.7",
     "typescript": "^3.8.2"
@@ -148,6 +147,7 @@
     "redux": "^4.0.0",
     "shortid": "^2.2.14",
     "socket.io": "^2.1.1",
+    "ts-toolbelt": "^6.3.6",
     "uuid": "3.2.1"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "main": "dist/boardgameio.js",
   "unpkg": "dist/boardgameio.min.js",
   "module": "dist/boardgameio.es.js",
+  "types": "dist/types/src/types.d.ts",
   "files": [
     "dist/boardgameio.js",
     "dist/boardgameio.min.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 import { Object } from 'ts-toolbelt';
 import * as ActionCreators from './core/action-creators';
 import { Flow } from './core/flow';
+import * as StorageAPI from './server/db/base';
+
+export { StorageAPI };
 
 export interface State {
   G: object;


### PR DESCRIPTION
This PR makes three small improvements to how types are published and contributes towards #576. (I think only server types still need to be exposed.)

1. Moved `ts-toolbelt` from `devDependencies` to `dependencies`.

    While working with 0.39.2, I got errors because `ts-toolbelt` wasn’t installed and the exposed types depended on it.

2. Added a `types` field to the main boardgame.io package.json. Now the basic types in `src/types` can be consumed more simply:

    ```ts
    import { State } from 'boardgame.io';
    ```

3. Imported and exported the storage API types (`FetchResult` etc.) in `src/types` so they can be used in third-party database connectors:

    ```ts
    import { StorageAPI } from 'boardgame.io';
    const opts: StorageAPI.FetchOpts = { state: true };
    ```