### PR TITLE
add plugin types to ctx interface

### DIFF
--- a/src/plugins/plugin-events.ts
+++ b/src/plugins/plugin-events.ts
@@ -8,6 +8,17 @@
 
 import { Events } from './events/events';
 
+export interface EventsAPI {
+  endGame?(...args: any[]): any;
+  endPhase?(...args: any[]): any;
+  endStage?(...args: any[]): any;
+  endTurn?(...args: any[]): any;
+  pass?(...args: any[]): any;
+  setActivePlayers?(...args: any[]): any;
+  setPhase?(...args: any[]): any;
+  setStage?(...args: any[]): any;
+}
+
 export default {
   name: 'events',
 

--- a/src/plugins/plugin-events.ts
+++ b/src/plugins/plugin-events.ts
@@ -9,14 +9,14 @@
 import { Events } from './events/events';
 
 export interface EventsAPI {
-  endGame?(...args: any[]): any;
-  endPhase?(...args: any[]): any;
-  endStage?(...args: any[]): any;
-  endTurn?(...args: any[]): any;
-  pass?(...args: any[]): any;
-  setActivePlayers?(...args: any[]): any;
-  setPhase?(...args: any[]): any;
-  setStage?(...args: any[]): any;
+  endGame?(...args: any[]): void;
+  endPhase?(...args: any[]): void;
+  endStage?(...args: any[]): void;
+  endTurn?(...args: any[]): void;
+  pass?(...args: any[]): void;
+  setActivePlayers?(...args: any[]): void;
+  setPhase?(...args: any[]): void;
+  setStage?(...args: any[]): void;
 }
 
 export default {

--- a/src/plugins/plugin-player.ts
+++ b/src/plugins/plugin-player.ts
@@ -7,6 +7,9 @@
  */
 
 export interface PlayerAPI {
+  state: {
+    [playerId: string]: object;
+  };
   get(): any;
   set(value: any): any;
   opponent?: {

--- a/src/plugins/plugin-player.ts
+++ b/src/plugins/plugin-player.ts
@@ -6,6 +6,15 @@
  * https://opensource.org/licenses/MIT.
  */
 
+export interface PlayerAPI {
+  get(): any;
+  set(value: any): any;
+  opponent?: {
+    get(): any;
+    set(value: any): any;
+  };
+}
+
 /**
  * Plugin that maintains state for each player in G.players.
  * During a turn, G.player will contain the object for the current player.

--- a/src/plugins/plugin-player.ts
+++ b/src/plugins/plugin-player.ts
@@ -32,19 +32,18 @@ export default {
     return { players: api.state };
   },
 
-  api: ({ ctx, data }) => {
+  api: ({ ctx, data }): PlayerAPI => {
     let state = data.players;
-    let result = { state };
 
     const get = () => {
       return data.players[ctx.currentPlayer];
     };
-    result.get = get;
 
     const set = value => {
       return (state[ctx.currentPlayer] = value);
     };
-    result.set = set;
+
+    let result: PlayerAPI = { state, get, set };
 
     if (ctx.numPlayers === 2) {
       const other = ctx.currentPlayer === '0' ? '1' : '0';

--- a/src/plugins/plugin-random.ts
+++ b/src/plugins/plugin-random.ts
@@ -8,6 +8,23 @@
 
 import { Random } from './random/random';
 
+export interface RandomAPI {
+  D4(): number;
+  D4(diceCount: number): number[];
+  D6(): number;
+  D6(diceCount: number): number[];
+  D10(): number;
+  D10(diceCount: number): number[];
+  D12(): number;
+  D12(diceCount: number): number[];
+  D20(): number;
+  D20(diceCount: number): number[];
+  Die(spotvalue?: number): number;
+  Die(spotvalue: number, diceCount: number): number[];
+  Number(): number;
+  Shuffle<T>(deck: T[]): T[];
+}
+
 export default {
   name: 'random',
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,9 @@ import { Object } from 'ts-toolbelt';
 import * as ActionCreators from './core/action-creators';
 import { Flow } from './core/flow';
 import * as StorageAPI from './server/db/base';
+import { EventsAPI } from './plugins/plugin-events';
+import { PlayerAPI } from './plugins/plugin-player';
+import { RandomAPI } from './plugins/plugin-random';
 
 export { StorageAPI };
 
@@ -48,43 +51,6 @@ export interface Ctx {
   player?: PlayerAPI;
   // enhanced by random plugin
   random?: RandomAPI;
-}
-
-export interface EventsAPI {
-  endGame?(...args: any[]): any;
-  endPhase?(...args: any[]): any;
-  endStage?(...args: any[]): any;
-  endTurn?(...args: any[]): any;
-  pass?(...args: any[]): any;
-  setActivePlayers?(...args: any[]): any;
-  setPhase?(...args: any[]): any;
-  setStage?(...args: any[]): any;
-}
-
-export interface PlayerAPI {
-  get(): any;
-  set(value: any): any;
-  opponent?: {
-    get(): any;
-    set(value: any): any;
-  };
-}
-
-export interface RandomAPI {
-  D4(): number;
-  D4(diceCount: number): number[];
-  D6(): number;
-  D6(diceCount: number): number[];
-  D10(): number;
-  D10(diceCount: number): number[];
-  D12(): number;
-  D12(diceCount: number): number[];
-  D20(): number;
-  D20(diceCount: number): number[];
-  Die(spotvalue?: number): number;
-  Die(spotvalue: number, diceCount: number): number[];
-  Number(): number;
-  Shuffle<T>(deck: T[]): T[];
 }
 
 export interface PluginState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,49 @@ export interface Ctx {
   _random?: {
     seed: string | number;
   };
+  // enhanced by events plugin
+  events?: EventsAPI;
+  // enhanced by player plugin
+  player?: PlayerAPI;
+  // enhanced by random plugin
+  random?: RandomAPI;
+}
+
+export interface EventsAPI {
+  endGame?(...args: any[]): any;
+  endPhase?(...args: any[]): any;
+  endStage?(...args: any[]): any;
+  endTurn?(...args: any[]): any;
+  pass?(...args: any[]): any;
+  setActivePlayers?(...args: any[]): any;
+  setPhase?(...args: any[]): any;
+  setStage?(...args: any[]): any;
+}
+
+export interface PlayerAPI {
+  get(): any;
+  set(value: any): any;
+  opponent?: {
+    get(): any;
+    set(value: any): any;
+  };
+}
+
+export interface RandomAPI {
+  D4(): number;
+  D4(diceCount: number): number[];
+  D6(): number;
+  D6(diceCount: number): number[];
+  D10(): number;
+  D10(diceCount: number): number[];
+  D12(): number;
+  D12(diceCount: number): number[];
+  D20(): number;
+  D20(diceCount: number): number[];
+  Die(spotvalue?: number): number;
+  Die(spotvalue: number, diceCount: number): number[];
+  Number(): number;
+  Shuffle<T>(deck: T[]): T[];
 }
 
 export interface PluginState {


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).

When using the typings of `Ctx` I noticed it was missing the events. After having a look into the source code, I realized the `random` and `player` plugins also enhance the `Ctx` interface.

The name plugin implies that they are not necessarily defined, so I declared them optional.
Also it seems like specific event functions can be deactivated, so I declared those functions all optional as well. This has the downside, that you need to add checks or non-null assertions to your typescript code when calling those event functions.
 