### PR TITLE
refactor(db): Make log handling explicit in StorageAPI.setState

### DIFF
--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -299,13 +299,9 @@ export class Master {
     const { deltalog, ...stateWithoutDeltalog } = state;
 
     if (IsSynchronous(this.storageAPI)) {
-      this.storageAPI.setState(key, stateWithoutDeltalog);
-      this.storageAPI.appendLog(key, deltalog);
+      this.storageAPI.setState(key, stateWithoutDeltalog, deltalog);
     } else {
-      await Promise.all([
-        this.storageAPI.setState(key, stateWithoutDeltalog),
-        this.storageAPI.appendLog(key, deltalog),
-      ]);
+      await this.storageAPI.setState(key, stateWithoutDeltalog, deltalog);
     }
   }
 

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -296,13 +296,15 @@ export class Master {
       };
     });
 
+    const { deltalog, ...stateWithoutDeltalog } = state;
+
     if (IsSynchronous(this.storageAPI)) {
-      this.storageAPI.setState(key, state);
-      this.storageAPI.appendLog(key, state.deltalog);
+      this.storageAPI.setState(key, stateWithoutDeltalog);
+      this.storageAPI.appendLog(key, deltalog);
     } else {
       await Promise.all([
-        this.storageAPI.setState(key, state),
-        this.storageAPI.appendLog(key, state.deltalog),
+        this.storageAPI.setState(key, stateWithoutDeltalog),
+        this.storageAPI.appendLog(key, deltalog),
       ]);
     }
   }

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -298,8 +298,12 @@ export class Master {
 
     if (IsSynchronous(this.storageAPI)) {
       this.storageAPI.setState(key, state);
+      this.storageAPI.appendLog(key, state.deltalog);
     } else {
-      await this.storageAPI.setState(key, state);
+      await Promise.all([
+        this.storageAPI.setState(key, state),
+        this.storageAPI.appendLog(key, state.deltalog),
+      ]);
     }
   }
 

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -19,14 +19,14 @@ class AsyncStorage extends StorageAPI.Async {
 
   constructor(args: any = {}) {
     super();
-    const { createGame, fetch, setState, setMetadata, listGames, wipe } = args;
     this.mocks = {
-      createGame: createGame || jest.fn(),
-      setState: setState || jest.fn(),
-      fetch: fetch || jest.fn(() => ({})),
-      setMetadata: setMetadata || jest.fn(),
-      listGames: listGames || jest.fn(() => []),
-      wipe: wipe || jest.fn(),
+      createGame: args.createGame || jest.fn(),
+      setState: args.setState || jest.fn(),
+      fetch: args.fetch || jest.fn(() => ({})),
+      setMetadata: args.setMetadata || jest.fn(),
+      appendLog: args.appendLog || jest.fn(),
+      listGames: args.listGames || jest.fn(() => []),
+      wipe: args.wipe || jest.fn(),
     };
   }
 
@@ -46,6 +46,10 @@ class AsyncStorage extends StorageAPI.Async {
 
   async setMetadata(...args) {
     this.mocks.setMetadata(...args);
+  }
+
+  async appendLog(...args) {
+    this.mocks.appendLog(...args);
   }
 
   async wipe(...args) {

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -24,7 +24,6 @@ class AsyncStorage extends StorageAPI.Async {
       setState: args.setState || jest.fn(),
       fetch: args.fetch || jest.fn(() => ({})),
       setMetadata: args.setMetadata || jest.fn(),
-      appendLog: args.appendLog || jest.fn(),
       listGames: args.listGames || jest.fn(() => []),
       wipe: args.wipe || jest.fn(),
     };
@@ -46,10 +45,6 @@ class AsyncStorage extends StorageAPI.Async {
 
   async setMetadata(...args) {
     this.mocks.setMetadata(...args);
-  }
-
-  async appendLog(...args) {
-    this.mocks.appendLog(...args);
   }
 
   async wipe(...args) {

--- a/src/server/db/base.ts
+++ b/src/server/db/base.ts
@@ -73,8 +73,15 @@ export abstract class Async {
 
   /**
    * Update the game state.
+   *
+   * If passed a deltalog array, setState should append its contents to the
+   * existing log for this game.
    */
-  abstract setState(gameID: string, state: State): Promise<void>;
+  abstract setState(
+    gameID: string,
+    state: State,
+    deltalog?: LogEntry[]
+  ): Promise<void>;
 
   /**
    * Update the game metadata.
@@ -83,17 +90,6 @@ export abstract class Async {
     gameID: string,
     metadata: Server.GameMetadata
   ): Promise<void>;
-
-  /**
-   * Append actions to the game log.
-   *
-   * This method will receive an array of log entry objects, which should be
-   * appended to any existing log array. This might mean reading in the log,
-   * concatenating the new entries, and persisting the result, or the
-   * implementation might be able to append the deltalog entries directly
-   * without needing to read in the existing log.
-   */
-  abstract appendLog(gameID: string, deltalog: LogEntry[]): Promise<void>;
 
   /**
    * Fetch the game state.
@@ -141,24 +137,16 @@ export abstract class Sync {
 
   /**
    * Update the game state.
+   *
+   * If passed a deltalog array, setState should append its contents to the
+   * existing log for this game.
    */
-  abstract setState(gameID: string, state: State): void;
+  abstract setState(gameID: string, state: State, deltalog?: LogEntry[]): void;
 
   /**
    * Update the game metadata.
    */
   abstract setMetadata(gameID: string, metadata: Server.GameMetadata): void;
-
-  /**
-   * Append actions to the game log.
-   *
-   * This method will receive an array of log entry objects, which should be
-   * appended to any existing log array. This might mean reading in the log,
-   * concatenating the new entries, and persisting the result, or the
-   * implementation might be able to append the deltalog entries directly
-   * without needing to read in the existing log.
-   */
-  abstract appendLog(gameID: string, deltalog: LogEntry[]): void;
 
   /**
    * Fetch the game state.

--- a/src/server/db/base.ts
+++ b/src/server/db/base.ts
@@ -85,6 +85,17 @@ export abstract class Async {
   ): Promise<void>;
 
   /**
+   * Append actions to the game log.
+   *
+   * This method will receive an array of log entry objects, which should be
+   * appended to any existing log array. This might mean reading in the log,
+   * concatenating the new entries, and persisting the result, or the
+   * implementation might be able to append the deltalog entries directly
+   * without needing to read in the existing log.
+   */
+  abstract appendLog(gameID: string, deltalog: LogEntry[]): Promise<void>;
+
+  /**
    * Fetch the game state.
    */
   abstract fetch<O extends FetchOpts>(
@@ -137,6 +148,17 @@ export abstract class Sync {
    * Update the game metadata.
    */
   abstract setMetadata(gameID: string, metadata: Server.GameMetadata): void;
+
+  /**
+   * Append actions to the game log.
+   *
+   * This method will receive an array of log entry objects, which should be
+   * appended to any existing log array. This might mean reading in the log,
+   * concatenating the new entries, and persisting the result, or the
+   * implementation might be able to append the deltalog entries directly
+   * without needing to read in the existing log.
+   */
+  abstract appendLog(gameID: string, deltalog: LogEntry[]): void;
 
   /**
    * Fetch the game state.

--- a/src/server/db/flatfile.test.ts
+++ b/src/server/db/flatfile.test.ts
@@ -88,8 +88,8 @@ describe('FlatFile', () => {
       phase: '',
     };
 
-    await db.setState('gameID', { deltalog: [logEntry1] } as State);
-    await db.setState('gameID', { deltalog: [logEntry2] } as State);
+    await db.appendLog('gameID', [logEntry1]);
+    await db.appendLog('gameID', [logEntry2]);
 
     const result = await db.fetch('gameID', { log: true });
     expect(result.log).toEqual([logEntry1, logEntry2]);

--- a/src/server/db/flatfile.test.ts
+++ b/src/server/db/flatfile.test.ts
@@ -88,8 +88,8 @@ describe('FlatFile', () => {
       phase: '',
     };
 
-    await db.appendLog('gameID', [logEntry1]);
-    await db.appendLog('gameID', [logEntry2]);
+    await db.setState('gameID', null, [logEntry1]);
+    await db.setState('gameID', null, [logEntry2]);
 
     const result = await db.fetch('gameID', { log: true });
     expect(result.log).toEqual([logEntry1, logEntry2]);

--- a/src/server/db/flatfile.ts
+++ b/src/server/db/flatfile.ts
@@ -94,20 +94,19 @@ export class FlatFile extends StorageAPI.Async {
     return this.games.clear();
   }
 
-  async setState(id: string, state: State) {
+  async setState(id: string, state: State, deltalog?: LogEntry[]) {
+    if (deltalog && deltalog.length > 0) {
+      const key = LogKey(id);
+      const log: LogEntry[] =
+        ((await this.games.getItem(key)) as LogEntry[]) || [];
+      await this.games.setItem(key, log.concat(deltalog));
+    }
     return await this.games.setItem(id, state);
   }
 
   async setMetadata(id: string, metadata: Server.GameMetadata): Promise<void> {
     const key = MetadataKey(id);
     return await this.games.setItem(key, metadata);
-  }
-
-  async appendLog(id: string, deltalog: LogEntry[]) {
-    const key = LogKey(id);
-    const log: LogEntry[] =
-      ((await this.games.getItem(key)) as LogEntry[]) || [];
-    await this.games.setItem(key, log.concat(deltalog));
   }
 
   async wipe(id: string) {

--- a/src/server/db/flatfile.ts
+++ b/src/server/db/flatfile.ts
@@ -95,18 +95,19 @@ export class FlatFile extends StorageAPI.Async {
   }
 
   async setState(id: string, state: State) {
-    let log: LogEntry[] =
-      ((await this.games.getItem(LogKey(id))) as LogEntry[]) || [];
-    if (state.deltalog) {
-      log = log.concat(state.deltalog);
-    }
-    await this.games.setItem(LogKey(id), log);
     return await this.games.setItem(id, state);
   }
 
   async setMetadata(id: string, metadata: Server.GameMetadata): Promise<void> {
     const key = MetadataKey(id);
     return await this.games.setItem(key, metadata);
+  }
+
+  async appendLog(id: string, deltalog: LogEntry[]) {
+    const key = LogKey(id);
+    const log: LogEntry[] =
+      ((await this.games.getItem(key)) as LogEntry[]) || [];
+    await this.games.setItem(key, log.concat(deltalog));
   }
 
   async wipe(id: string) {

--- a/src/server/db/inmemory.ts
+++ b/src/server/db/inmemory.ts
@@ -48,16 +48,12 @@ export class InMemory extends StorageAPI.Sync {
   /**
    * Write the game state to the in-memory object.
    */
-  setState(gameID: string, state: State): void {
+  setState(gameID: string, state: State, deltalog?: LogEntry[]): void {
+    if (deltalog && deltalog.length > 0) {
+      const log = this.log.get(gameID) || [];
+      this.log.set(gameID, log.concat(deltalog));
+    }
     this.state.set(gameID, state);
-  }
-
-  /**
-   * Append actions to the game log.
-   */
-  appendLog(gameID: string, deltalog: LogEntry[]) {
-    const log = this.log.get(gameID) || [];
-    this.log.set(gameID, log.concat(deltalog));
   }
 
   /**

--- a/src/server/db/inmemory.ts
+++ b/src/server/db/inmemory.ts
@@ -50,12 +50,14 @@ export class InMemory extends StorageAPI.Sync {
    */
   setState(gameID: string, state: State): void {
     this.state.set(gameID, state);
+  }
 
-    let log = this.log.get(gameID) || [];
-    if (state.deltalog) {
-      log = log.concat(state.deltalog);
-    }
-    this.log.set(gameID, log);
+  /**
+   * Append actions to the game log.
+   */
+  appendLog(gameID: string, deltalog: LogEntry[]) {
+    const log = this.log.get(gameID) || [];
+    this.log.set(gameID, log.concat(deltalog));
   }
 
   /**


### PR DESCRIPTION
~~Move the log concatenation logic out of `setState` and into a separate `appendLog` method.~~

Add a `deltalog` parameter to the `StorageAPI.setState` method to make it more obvious that `setState` should also handle appending entries to the game log.

Closes #577.