### PR TITLE
fix(db): Make listGames options optional

### DIFF
--- a/src/server/db/base.ts
+++ b/src/server/db/base.ts
@@ -107,7 +107,7 @@ export abstract class Async {
   /**
    * Return all games.
    */
-  abstract listGames(opts: ListGamesOpts): Promise<string[]>;
+  abstract listGames(opts?: ListGamesOpts): Promise<string[]>;
 }
 
 export abstract class Sync {
@@ -161,5 +161,5 @@ export abstract class Sync {
   /**
    * Return all games.
    */
-  abstract listGames(opts: ListGamesOpts): string[];
+  abstract listGames(opts?: ListGamesOpts): string[];
 }

--- a/src/server/db/inmemory.ts
+++ b/src/server/db/inmemory.ts
@@ -95,8 +95,8 @@ export class InMemory extends StorageAPI.Sync {
   /**
    * Return all keys.
    */
-  listGames(opts: StorageAPI.ListGamesOpts): string[] {
-    if (opts.gameName !== undefined) {
+  listGames(opts?: StorageAPI.ListGamesOpts): string[] {
+    if (opts && opts.gameName !== undefined) {
       let gameIDs = [];
       this.metadata.forEach((metadata, gameID) => {
         if (metadata.gameName === opts.gameName) {


### PR DESCRIPTION
The database interfaces currently declare the `listGames` method as requiring an options object which can optionally include a `gameName`. The options object itself should be optional so we don’t have to do `listGames({})`. (This isn’t an issue with internal boardgame.io code, because it doesn’t currently use Typescript’s strict mode, but this helps for external libraries that do.)