### PR TITLE
feat(types): Replace Function constructor typings with function types

### DIFF
--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -76,7 +76,7 @@ export function Flow({
 
   Object.keys(moves).forEach(name => moveNames.add(name));
 
-  const HookWrapper = (fn: Function) => {
+  const HookWrapper = (fn: (G: any, ctx: Ctx) => any) => {
     const withPlugins = plugin.FnWrap(fn, plugins);
     return (state: State) => {
       const ctxWithAPI = plugin.EnhanceCtx(state);
@@ -84,7 +84,7 @@ export function Flow({
     };
   };
 
-  const TriggerWrapper = (endIf: Function) => {
+  const TriggerWrapper = (endIf: (G: any, ctx: Ctx) => any) => {
     return (state: State) => {
       let ctxWithAPI = plugin.EnhanceCtx(state);
       return endIf(state.G, ctxWithAPI);
@@ -399,12 +399,12 @@ export function Flow({
     return wrapped.endIf(state);
   }
 
-  function ShouldEndPhase(state: State): boolean {
+  function ShouldEndPhase(state: State): boolean | void {
     const conf = GetPhase(state.ctx);
     return conf.wrapped.endIf(state);
   }
 
-  function ShouldEndTurn(state: State): boolean {
+  function ShouldEndTurn(state: State): boolean | void {
     const conf = GetPhase(state.ctx);
 
     // End the turn if the required number of moves has been made.

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -8,14 +8,18 @@
 
 import * as plugins from '../plugins/main';
 import { Flow } from './flow';
+import { INVALID_MOVE } from './reducer';
 import { ActionPayload, GameConfig, Move, LongFormMove, State } from '../types';
 import * as logging from './logger';
 
 type ProcessedGameConfig = GameConfig & {
-  flow: object;
+  flow: ReturnType<typeof Flow>;
   moveNames: string[];
   pluginNames: string[];
-  processMove: Function;
+  processMove: (
+    state: State,
+    action: ActionPayload.MakeMove
+  ) => State | typeof INVALID_MOVE;
 };
 
 function IsProcessed(

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -12,6 +12,7 @@ import { Game } from './game';
 import { error } from './logger';
 import {
   ActionShape,
+  Ctx,
   GameConfig,
   LogEntry,
   State,
@@ -22,12 +23,14 @@ import {
 /**
  * Returns true if a move can be undone.
  */
-const CanUndoMove = (G: object, ctx: object, move: Move): boolean => {
+const CanUndoMove = (G: any, ctx: Ctx, move: Move): boolean => {
   function HasUndoable(move: Move): move is LongFormMove {
     return (move as LongFormMove).undoable !== undefined;
   }
 
-  function IsFunction(undoable: boolean | Function): undoable is Function {
+  function IsFunction(
+    undoable: boolean | ((...args: any[]) => any)
+  ): undoable is (...args: any[]) => any {
     return undoable instanceof Function;
   }
 

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -88,7 +88,7 @@ export const EnhanceCtx = (state: PartialGameState): Ctx => {
  * @param {function} fn - The move function or trigger to apply the plugins to.
  * @param {object} plugins - The list of plugins.
  */
-export const FnWrap = (fn: Function, plugins: Plugin[]) => {
+export const FnWrap = (fn: (...args: any[]) => any, plugins: Plugin[]) => {
   const reducer = (acc, { fnWrap }) => fnWrap(acc, plugins);
   return [...DEFAULT_PLUGINS, ...plugins]
     .filter(plugin => plugin.fnWrap !== undefined)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { Object } from 'ts-toolbelt';
 import * as ActionCreators from './core/action-creators';
 import { Flow } from './core/flow';
+import { INVALID_MOVE } from './core/reducer';
 import * as StorageAPI from './server/db/base';
 import { EventsAPI } from './plugins/plugin-events';
 import { PlayerAPI } from './plugins/plugin-player';
@@ -67,22 +68,27 @@ export interface LogEntry {
   automatic?: boolean;
 }
 
-export interface Plugin {
+export interface Plugin<API extends any = any, Data extends any = any> {
   name: string;
-  setup?: Function;
-  action?: Function;
-  api?: Function;
-  flush?: Function;
+  setup?: (setupCtx: { ctx: Ctx }) => Data;
+  action?: (data: Data, payload: ActionShape.Plugin['payload']) => Data;
+  api?: (apiCtx: { G: any; ctx: Ctx; data: Data }) => API;
+  flush?: (flushCtx: { G: any; ctx: Ctx; data: Data; api: API }) => Data;
+  fnWrap?: (
+    fn: (...args: any[]) => any
+  ) => (G: any, ctx: Ctx, ...args: any[]) => any;
 }
+
+type MoveFn<A extends any[] = any[]> = (G: any, ctx: Ctx, ...args: A) => any;
 
 export interface LongFormMove {
-  move: Function;
+  move: MoveFn;
   redact?: boolean;
   client?: boolean;
-  undoable?: boolean | Function;
+  undoable?: boolean | ((G: any, ctx: Ctx) => boolean);
 }
 
-export type Move = Function | LongFormMove;
+export type Move = MoveFn | LongFormMove;
 
 export interface MoveMap {
   [moveName: string]: Move;
@@ -91,15 +97,15 @@ export interface MoveMap {
 export interface PhaseConfig {
   start?: boolean;
   next?: string;
-  onBegin?: Function;
-  onEnd?: Function;
-  endIf?: Function;
+  onBegin?: (G: any, ctx: Ctx) => any;
+  onEnd?: (G: any, ctx: Ctx) => any;
+  endIf?: (G: any, ctx: Ctx) => boolean | void;
   moves?: MoveMap;
   turn?: TurnConfig;
   wrapped?: {
-    endIf?: Function;
-    onBegin?: Function;
-    onEnd?: Function;
+    endIf?: (state: State) => boolean | void;
+    onBegin?: (state: State) => any;
+    onEnd?: (state: State) => any;
   };
 }
 
@@ -115,18 +121,18 @@ export interface StageMap {
 export interface TurnConfig {
   activePlayers?: object;
   moveLimit?: number;
-  onBegin?: Function;
-  onEnd?: Function;
-  endIf?: Function;
-  onMove?: Function;
+  onBegin?: (G: any, ctx: Ctx) => any;
+  onEnd?: (G: any, ctx: Ctx) => any;
+  endIf?: (G: any, ctx: Ctx) => boolean | void;
+  onMove?: (G: any, ctx: Ctx) => any;
   stages?: StageMap;
   moves?: MoveMap;
   order?: object;
   wrapped?: {
-    endIf?: Function;
-    onBegin?: Function;
-    onEnd?: Function;
-    onMove?: Function;
+    endIf?: (state: State) => boolean | void;
+    onBegin?: (state: State) => any;
+    onEnd?: (state: State) => any;
+    onMove?: (state: State) => any;
   };
 }
 
@@ -137,7 +143,7 @@ interface PhaseMap {
 export interface GameConfig {
   name?: string;
   seed?: string | number;
-  setup?: Function;
+  setup?: (ctx: Ctx, setupData?: any) => any;
   moves?: MoveMap;
   phases?: PhaseMap;
   turn?: TurnConfig;
@@ -151,11 +157,14 @@ export interface GameConfig {
     pass?: boolean;
     setActivePlayers?: boolean;
   };
-  endIf?: Function;
-  onEnd?: Function;
-  playerView?: Function;
+  endIf?: (G: any, ctx: Ctx) => any;
+  onEnd?: (G: any, ctx: Ctx) => any;
+  playerView?: (G: any, ctx: Ctx, playerID: PlayerID) => any;
   plugins?: Array<Plugin>;
-  processMove?: Function;
+  processMove?: (
+    state: State,
+    action: ActionPayload.MakeMove
+  ) => State | typeof INVALID_MOVE;
   flow?: ReturnType<typeof Flow>;
 }
 


### PR DESCRIPTION
This replaces places where `Function` (the Javascript function constructor) was used as a type with actual function types, trying to be as accurate as possible about the expected function signatures. It might be worth double checking in case I’ve mis-typed something.

Example of what I mean by `Function` constructor vs function type:

```diff
- interface Foo { fn: Function }
+ interface Foo { fn: (...args: any[]) => any }
```

Fixes #587.