### PR TITLE
Include credentials in undo/redo actions

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -98,10 +98,10 @@ class _ClientImpl {
       this.store.dispatch(ActionCreators.reset(this.initialState));
     };
     this.undo = () => {
-      this.store.dispatch(ActionCreators.undo());
+      this.store.dispatch(ActionCreators.undo(playerID, credentials));
     };
     this.redo = () => {
-      this.store.dispatch(ActionCreators.redo());
+      this.store.dispatch(ActionCreators.redo(playerID, credentials));
     };
 
     this.store = null;

--- a/src/core/action-creators.ts
+++ b/src/core/action-creators.ts
@@ -96,16 +96,22 @@ export const reset = (state: State) => ({
 
 /**
  * Used to undo the last move.
+ * @param {string}  playerID - The ID of the player making this action.
+ * @param {string}  credentials - (optional) The credentials for the player making this action.
  */
-export const undo = () => ({
+export const undo = (playerID?: string | null, credentials?: string) => ({
   type: Actions.UNDO as typeof Actions.UNDO,
+  payload: { type: null, args: null, playerID, credentials },
 });
 
 /**
  * Used to redo the last undone move.
+ * @param {string}  playerID - The ID of the player making this action.
+ * @param {string}  credentials - (optional) The credentials for the player making this action.
  */
-export const redo = () => ({
+export const redo = (playerID?: string | null, credentials?: string) => ({
   type: Actions.REDO as typeof Actions.REDO,
+  payload: { type: null, args: null, playerID, credentials },
 });
 
 /**

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -106,15 +106,10 @@ export const isActionFromAuthenticPlayer = (
 /**
  * Remove player credentials from action payload
  */
-const stripCredentialsFromAction = (
-  action: CredentialedActionShape.Any | ActionShape.Any
-) => {
-  if ('payload' in action && 'credentials' in action.payload) {
-    // eslint-disable-next-line no-unused-vars
-    const { credentials, ...payload } = action.payload;
-    return { ...action, payload };
-  }
-  return action;
+const stripCredentialsFromAction = (action: CredentialedActionShape.Any) => {
+  // eslint-disable-next-line no-unused-vars
+  const { credentials, ...payload } = action.payload;
+  return { ...action, payload };
 };
 
 type AuthFn = (
@@ -175,16 +170,13 @@ export class Master {
    * along with a deltalog.
    */
   async onUpdate(
-    action: CredentialedActionShape.Any | ActionShape.Any,
+    credAction: CredentialedActionShape.Any,
     stateID: number,
     gameID: string,
     playerID: string
   ) {
     let isActionAuthentic;
-    const credentials =
-      'payload' in action && 'credentials' in action.payload
-        ? action.payload.credentials
-        : undefined;
+    const credentials = credAction.payload.credentials;
     if (IsSynchronous(this.storageAPI)) {
       const { metadata } = this.storageAPI.fetch(gameID, { metadata: true });
       const playerMetadata = getPlayerMetadata(metadata, playerID);
@@ -204,8 +196,7 @@ export class Master {
       return { error: 'unauthorized action' };
     }
 
-    action = stripCredentialsFromAction(action);
-
+    let action = stripCredentialsFromAction(credAction);
     const key = gameID;
 
     let state: State;

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,7 +199,7 @@ export namespace CredentialedActionShape {
     | ActionShape.Reset
     | ActionShape.Undo
     | ActionShape.Redo
-    | ActionShape.Plugin;
+    | Plugin;
 }
 
 export namespace ActionShape {

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,15 +190,14 @@ export namespace CredentialedActionShape {
   export type AutomaticGameEvent = ReturnType<
     typeof ActionCreators.automaticGameEvent
   >;
+  export type Undo = ReturnType<typeof ActionCreators.undo>;
+  export type Redo = ReturnType<typeof ActionCreators.redo>;
   export type Any =
     | MakeMove
     | GameEvent
     | AutomaticGameEvent
-    | ActionShape.Sync
-    | ActionShape.Update
-    | ActionShape.Reset
-    | ActionShape.Undo
-    | ActionShape.Redo
+    | Undo
+    | Redo
     | Plugin;
 }
 
@@ -216,8 +215,8 @@ export namespace ActionShape {
   export type Sync = ReturnType<typeof ActionCreators.sync>;
   export type Update = ReturnType<typeof ActionCreators.update>;
   export type Reset = ReturnType<typeof ActionCreators.reset>;
-  export type Undo = ReturnType<typeof ActionCreators.undo>;
-  export type Redo = ReturnType<typeof ActionCreators.redo>;
+  export type Undo = StripCredentials<CredentialedActionShape.Undo>;
+  export type Redo = StripCredentials<CredentialedActionShape.Redo>;
   export type Any =
     | MakeMove
     | GameEvent


### PR DESCRIPTION
If playing on a remote server, actions are validated wrt player
credentials that are assumed to be inside action.payload.credentials:
https://github.com/nicolodavis/boardgame.io/blob/v0.39.3/src/master/master.ts#L188

However, in case of undo and redo, the client sends an action that
consists only of type:
https://github.com/nicolodavis/boardgame.io/blob/v0.39.3/src/core/action-creators.ts#L97

Make it possible to undo/redo with a remote server and fix #593 by
adding credentials to undo/redo actions.

#### Checklist

* [v] Use a separate branch in your local repo (not `master`).
* [v] Test coverage is 100% (or you have a story for why it's ok).
