### PR TITLE
refactor(core): More Typescript conversion

### DIFF
--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -10,9 +10,9 @@ const production = process.env.NODE_ENV === 'production';
 const logfn = production ? () => {} : console.log;
 const errorfn = console.error;
 
-export function info(msg) {
+export function info(msg: string) {
   logfn(`INFO: ${msg}`);
 }
-export function error(error) {
+export function error(error: string) {
   errorfn('ERROR:', error);
 }

--- a/src/core/player-view.ts
+++ b/src/core/player-view.ts
@@ -6,6 +6,8 @@
  * https://opensource.org/licenses/MIT.
  */
 
+import { Ctx, PlayerID } from '../types';
+
 /**
  * PlayerView reducers.
  */
@@ -17,7 +19,7 @@ export const PlayerView = {
    * removes all the keys in `players`, except for the one
    * corresponding to the current playerID.
    */
-  STRIP_SECRETS: (G, ctx, playerID) => {
+  STRIP_SECRETS: (G: any, ctx: Ctx, playerID: PlayerID) => {
     let r = { ...G };
 
     if (r.secret !== undefined) {

--- a/src/core/turn-order.ts
+++ b/src/core/turn-order.ts
@@ -209,7 +209,8 @@ function getCurrentPlayer(
   playOrder: Ctx['playOrder'],
   playOrderPos: Ctx['playOrderPos']
 ) {
-  return playOrder[playOrderPos];
+  // convert to string in case playOrder is set to number[]
+  return playOrder[playOrderPos] + '';
 }
 
 /**

--- a/src/core/turn-order.ts
+++ b/src/core/turn-order.ts
@@ -7,88 +7,104 @@
  */
 
 import * as logging from './logger';
+import {
+  Ctx,
+  StageArg,
+  ActivePlayersArg,
+  PlayerID,
+  State,
+  TurnConfig,
+} from '../types';
 
 /**
  * Event to change the active players (and their stages) in the current turn.
  */
-export function SetActivePlayersEvent(state, _playerID, arg) {
+export function SetActivePlayersEvent(
+  state: State,
+  _playerID: PlayerID,
+  arg: ActivePlayersArg | PlayerID[]
+) {
   return { ...state, ctx: SetActivePlayers(state.ctx, arg) };
 }
 
-export function SetActivePlayers(ctx, arg) {
+export function SetActivePlayers(ctx: Ctx, arg: ActivePlayersArg | PlayerID[]) {
   let { _prevActivePlayers } = ctx;
-
-  const _nextActivePlayers = arg.next || null;
-
-  if (arg.revert) {
-    _prevActivePlayers = _prevActivePlayers.concat({
-      activePlayers: ctx.activePlayers,
-      _activePlayersMoveLimit: ctx._activePlayersMoveLimit,
-      _activePlayersNumMoves: ctx._activePlayersNumMoves,
-    });
-  } else {
-    _prevActivePlayers = [];
-  }
-
   let activePlayers = {};
+  let _nextActivePlayers: ActivePlayersArg | null = null;
   let _activePlayersMoveLimit = {};
 
   if (Array.isArray(arg)) {
+    // support a simple array of player IDs as active players
     let value = {};
     arg.forEach(v => (value[v] = Stage.NULL));
     activePlayers = value;
-  }
+  } else {
+    // process active players argument object
+    if (arg.next) {
+      _nextActivePlayers = arg.next;
+    }
 
-  if (arg.currentPlayer !== undefined) {
-    ApplyActivePlayerArgument(
-      activePlayers,
-      _activePlayersMoveLimit,
-      ctx.currentPlayer,
-      arg.currentPlayer
-    );
-  }
+    if (arg.revert) {
+      _prevActivePlayers = _prevActivePlayers.concat({
+        activePlayers: ctx.activePlayers,
+        _activePlayersMoveLimit: ctx._activePlayersMoveLimit,
+        _activePlayersNumMoves: ctx._activePlayersNumMoves,
+      });
+    } else {
+      _prevActivePlayers = [];
+    }
 
-  if (arg.others !== undefined) {
-    for (let i = 0; i < ctx.playOrder.length; i++) {
-      const id = ctx.playOrder[i];
-      if (id !== ctx.currentPlayer) {
+    if (arg.currentPlayer !== undefined) {
+      ApplyActivePlayerArgument(
+        activePlayers,
+        _activePlayersMoveLimit,
+        ctx.currentPlayer,
+        arg.currentPlayer
+      );
+    }
+
+    if (arg.others !== undefined) {
+      for (let i = 0; i < ctx.playOrder.length; i++) {
+        const id = ctx.playOrder[i];
+        if (id !== ctx.currentPlayer) {
+          ApplyActivePlayerArgument(
+            activePlayers,
+            _activePlayersMoveLimit,
+            id,
+            arg.others
+          );
+        }
+      }
+    }
+
+    if (arg.all !== undefined) {
+      for (let i = 0; i < ctx.playOrder.length; i++) {
+        const id = ctx.playOrder[i];
         ApplyActivePlayerArgument(
           activePlayers,
           _activePlayersMoveLimit,
           id,
-          arg.others
+          arg.all
         );
       }
     }
-  }
 
-  if (arg.all !== undefined) {
-    for (let i = 0; i < ctx.playOrder.length; i++) {
-      const id = ctx.playOrder[i];
-      ApplyActivePlayerArgument(
-        activePlayers,
-        _activePlayersMoveLimit,
-        id,
-        arg.all
-      );
+    if (arg.value) {
+      for (const id in arg.value) {
+        ApplyActivePlayerArgument(
+          activePlayers,
+          _activePlayersMoveLimit,
+          id,
+          arg.value[id]
+        );
+      }
     }
-  }
 
-  if (arg.value) {
-    for (const id in arg.value) {
-      ApplyActivePlayerArgument(
-        activePlayers,
-        _activePlayersMoveLimit,
-        id,
-        arg.value[id]
-      );
-    }
-  }
-
-  if (arg.moveLimit) {
-    for (const id in activePlayers) {
-      if (_activePlayersMoveLimit[id] === undefined) {
-        _activePlayersMoveLimit[id] = arg.moveLimit;
+    if (arg.moveLimit) {
+      for (const id in activePlayers) {
+        if (_activePlayersMoveLimit[id] === undefined) {
+          _activePlayersMoveLimit[id] = arg.moveLimit;
+        }
       }
     }
   }
@@ -119,9 +135,9 @@ export function SetActivePlayers(ctx, arg) {
 /**
  * Update activePlayers, setting it to previous, next or null values
  * when it becomes empty.
- * @param {Object} ctx
+ * @param ctx
  */
-export function UpdateActivePlayersOnceEmpty(ctx) {
+export function UpdateActivePlayersOnceEmpty(ctx: Ctx) {
   let {
     activePlayers,
     _activePlayersMoveLimit,
@@ -169,13 +185,13 @@ export function UpdateActivePlayersOnceEmpty(ctx) {
  * @param {(String|Object)} arg An active player argument
  */
 function ApplyActivePlayerArgument(
-  activePlayers,
-  _activePlayersMoveLimit,
-  playerID,
-  arg
+  activePlayers: Ctx['activePlayers'],
+  _activePlayersMoveLimit: Ctx['_activePlayersMoveLimit'],
+  playerID: PlayerID,
+  arg: StageArg
 ) {
   if (typeof arg !== 'object' || arg === Stage.NULL) {
-    arg = { stage: arg };
+    arg = { stage: arg as string | null };
   }
 
   if (arg.stage !== undefined) {
@@ -189,8 +205,11 @@ function ApplyActivePlayerArgument(
  * @param {Array} playOrder - An array of player ID's.
  * @param {number} playOrderPos - An index into the above.
  */
-function getCurrentPlayer(playOrder, playOrderPos) {
-  return playOrder[playOrderPos] + '';
+function getCurrentPlayer(
+  playOrder: Ctx['playOrder'],
+  playOrderPos: Ctx['playOrderPos']
+) {
+  return playOrder[playOrderPos];
 }
 
 /**
@@ -205,10 +224,10 @@ function getCurrentPlayer(playOrder, playOrderPos) {
  * @param {object} ctx - The game object ctx.
  * @param {object} turn - A turn object for this phase.
  */
-export function InitTurnOrderState(G, ctx, turn) {
+export function InitTurnOrderState(G: any, ctx: Ctx, turn: TurnConfig) {
   const order = turn.order;
 
-  let playOrder = [...new Array(ctx.numPlayers)].map((d, i) => i + '');
+  let playOrder = [...new Array(ctx.numPlayers)].map((_, i) => i + '');
   if (order.playOrder !== undefined) {
     playOrder = order.playOrder(G, ctx);
   }
@@ -230,7 +249,12 @@ export function InitTurnOrderState(G, ctx, turn) {
  * @param {string} endTurnArg - An optional argument to endTurn that
                                 may specify the next player.
  */
-export function UpdateTurnOrderState(G, ctx, turn, endTurnArg) {
+export function UpdateTurnOrderState(
+  G: any,
+  ctx: Ctx,
+  turn: TurnConfig,
+  endTurnArg?: true | { remove: any; next: string }
+) {
   const order = turn.order;
 
   let playOrderPos = ctx.playOrderPos;
@@ -293,11 +317,11 @@ export const TurnOrder = {
    * The default round-robin turn order.
    */
   DEFAULT: {
-    first: (G, ctx) =>
+    first: (G: any, ctx: Ctx) =>
       ctx.turn === 0
         ? ctx.playOrderPos
         : (ctx.playOrderPos + 1) % ctx.playOrder.length,
-    next: (G, ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
+    next: (G: any, ctx: Ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
   },
 
   /**
@@ -307,7 +331,7 @@ export const TurnOrder = {
    */
   RESET: {
     first: () => 0,
-    next: (G, ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
+    next: (G: any, ctx: Ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
   },
 
   /**
@@ -316,8 +340,8 @@ export const TurnOrder = {
    * Similar to DEFAULT, but starts with the player who ended the last phase.
    */
   CONTINUE: {
-    first: (G, ctx) => ctx.playOrderPos,
-    next: (G, ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
+    first: (G: any, ctx: Ctx) => ctx.playOrderPos,
+    next: (G: any, ctx: Ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
   },
 
   /**
@@ -328,7 +352,7 @@ export const TurnOrder = {
    */
   ONCE: {
     first: () => 0,
-    next: (G, ctx) => {
+    next: (G: any, ctx: Ctx) => {
       if (ctx.playOrderPos < ctx.playOrder.length - 1) {
         return ctx.playOrderPos + 1;
       }
@@ -343,10 +367,10 @@ export const TurnOrder = {
    *
    * @param {Array} playOrder - The play order.
    */
-  CUSTOM: playOrder => ({
+  CUSTOM: (playOrder: string[]) => ({
     playOrder: () => playOrder,
     first: () => 0,
-    next: (G, ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
+    next: (G: any, ctx: Ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
   }),
 
   /**
@@ -358,10 +382,10 @@ export const TurnOrder = {
    *
    * @param {string} playOrderField - Field in G.
    */
-  CUSTOM_FROM: playOrderField => ({
-    playOrder: G => G[playOrderField],
+  CUSTOM_FROM: (playOrderField: string) => ({
+    playOrder: (G: any) => G[playOrderField],
     first: () => 0,
-    next: (G, ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
+    next: (G: any, ctx: Ctx) => (ctx.playOrderPos + 1) % ctx.playOrder.length,
   }),
 };
 

--- a/src/core/turn-order.ts
+++ b/src/core/turn-order.ts
@@ -233,6 +233,12 @@ export function InitTurnOrderState(G: any, ctx: Ctx, turn: TurnConfig) {
   }
 
   const playOrderPos = order.first(G, ctx);
+  const posType = typeof playOrderPos;
+  if (posType !== 'number') {
+    logging.error(
+      `invalid value returned by turn.order.first — expected number got ${posType} “${playOrderPos}”.`
+    );
+  }
   const currentPlayer = getCurrentPlayer(playOrder, playOrderPos);
 
   ctx = { ...ctx, currentPlayer, playOrderPos, playOrder };
@@ -281,6 +287,12 @@ export function UpdateTurnOrderState(
     });
   } else {
     const t = order.next(G, ctx);
+    const type = typeof t;
+    if (type !== 'number') {
+      logging.error(
+        `invalid value returned by turn.order.next — expected number got ${type} “${t}”.`
+      );
+    }
 
     if (t === undefined) {
       endPhase = true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,19 @@ export type PartialGameState = Pick<State, 'G' | 'ctx' | 'plugins'>;
 export type StageName = string;
 export type PlayerID = string;
 
-interface ActivePlayers {
+export type StageArg = StageName | { stage?: StageName; moveLimit?: number };
+
+export interface ActivePlayersArg {
+  currentPlayer?: StageArg;
+  others?: StageArg;
+  all?: StageArg;
+  value?: Record<PlayerID, StageArg>;
+  moveLimit?: number;
+  revert?: boolean;
+  next?: ActivePlayersArg;
+}
+
+export interface ActivePlayers {
   [playerID: string]: StageName;
 }
 
@@ -41,9 +53,14 @@ export interface Ctx {
   gameover?: any;
   turn: number;
   phase: string;
-  _activePlayersMoveLimit?: object;
-  _activePlayersNumMoves?: object;
-  _prevActivePlayers?: Array<object>;
+  _activePlayersMoveLimit?: Record<PlayerID, number>;
+  _activePlayersNumMoves?: Record<PlayerID, number>;
+  _prevActivePlayers?: Array<{
+    activePlayers: null | ActivePlayers;
+    _activePlayersMoveLimit?: Record<PlayerID, number>;
+    _activePlayersNumMoves?: Record<PlayerID, number>;
+  }>;
+  _nextActivePlayers?: ActivePlayersArg;
   _random?: {
     seed: string | number;
   };
@@ -119,6 +136,12 @@ export interface StageMap {
   [stageName: string]: StageConfig;
 }
 
+export interface TurnOrderConfig {
+  first: (G: any, ctx: Ctx) => number;
+  next: (G: any, ctx: Ctx) => number;
+  playOrder?: (G: any, ctx: Ctx) => PlayerID[];
+}
+
 export interface TurnConfig {
   activePlayers?: object;
   moveLimit?: number;
@@ -128,7 +151,7 @@ export interface TurnConfig {
   onMove?: (G: any, ctx: Ctx) => any;
   stages?: StageMap;
   moves?: MoveMap;
-  order?: object;
+  order?: TurnOrderConfig;
   wrapped?: {
     endIf?: (state: State) => boolean | void;
     onBegin?: (state: State) => any;


### PR DESCRIPTION
I’ve converted the turn order code to Typescript, in the process typing the turn order config object.

I’ve also added logging when `first` or `next` don’t return numbers as suggested in #586.

Between Typescript type checking and error logging, hopefully this will help people debug errors in their turn order settings.