### PR TITLE
fix(plugins): More Typescript & pass playerID to Enhance

### DIFF
--- a/docs/documentation/plugins.md
+++ b/docs/documentation/plugins.md
@@ -16,30 +16,36 @@ A plugin is an object that contains the following fields.
   // Initialize the plugin's data.
   // This is stored in a special area of the state object
   // and not exposed to the move functions.
-  setup: ({ ctx }) => object,
+  setup: ({ G, ctx, game }) => data object,
 
   // Create an object that becomes available in `ctx`
   // under `ctx['plugin-name']`.
   // This is called at the beginning of a move or event.
   // This object will be held in memory until flush (below)
   // is called.
-  api: ({ G, ctx, data }) => object,
+  api: ({ G, ctx, game, data, playerID }) => api object,
 
   // Return an updated version of data that is persisted
   // in the game's state object.
-  flush: ({ G, ctx, data, api }) => object,
+  flush: ({ G, ctx, game, data, api }) => data object,
 
   // Function that accepts a move / trigger function
   // and returns another function that wraps it. This
   // wrapper can modify G before passing it down to
   // the wrapped function. It is a good practice to
   // undo the change at the end of the call.
-  fnWrap: (fn, game) => (G, ctx, ...args) => {
+  fnWrap: (fn) => (G, ctx, ...args) => {
     G = preprocess(G);
     G = fn(G, ctx, ...args);
     G = postprocess(G);
     return G;
   },
+  
+  // Function that allows the plugin to indicate that it
+  // should not be run on the client. If it returns true,
+  // the client will discard the state update and wait
+  // for the master instead.
+  noClient: ({ G, ctx, game, data, api }) => boolean,
 }
 ```
 

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -96,11 +96,11 @@ export function Game(
           ...plugins.EnhanceCtx(state),
           playerID: action.playerID,
         };
-        let args = [state.G, ctxWithAPI];
+        let args = [];
         if (action.args !== undefined) {
           args = args.concat(action.args);
         }
-        return fn(...args);
+        return fn(state.G, ctxWithAPI, ...args);
       }
 
       logging.error(`invalid move object: ${action.type}`);

--- a/src/core/initialize.ts
+++ b/src/core/initialize.ts
@@ -42,7 +42,7 @@ export function InitializeGame({
 
   // Run plugins over initial state.
   state = plugins.Setup(state, { game });
-  state = plugins.Enhance(state as State, { game });
+  state = plugins.Enhance(state as State, { game, playerID: undefined });
 
   const enhancedCtx = plugins.EnhanceCtx(state);
   state.G = game.setup(enhancedCtx, setupData);

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -103,7 +103,11 @@ export function CreateGameReducer({
         }
 
         // Execute plugins.
-        state = plugins.Enhance(state, { game, isClient: false });
+        state = plugins.Enhance(state, {
+          game,
+          isClient: false,
+          playerID: action.payload.playerID,
+        });
 
         // Process event.
         let newState = game.flow.processEvent(state, action);
@@ -153,6 +157,7 @@ export function CreateGameReducer({
         state = plugins.Enhance(state, {
           game,
           isClient,
+          playerID: action.payload.playerID,
         });
 
         // Process the move.

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -17,6 +17,7 @@ import {
   Plugin,
   Ctx,
   ActionShape,
+  PlayerID,
 } from '../types';
 
 interface PluginOpts {
@@ -130,7 +131,10 @@ export const Setup = (
  * the `plugins` section of the state (which is subsequently
  * merged into ctx).
  */
-export const Enhance = (state: State, opts: PluginOpts): State => {
+export const Enhance = (
+  state: State,
+  opts: PluginOpts & { playerID: PlayerID }
+): State => {
   [...DEFAULT_PLUGINS, ...opts.game.plugins]
     .filter(plugin => plugin.api !== undefined)
     .forEach(plugin => {
@@ -142,6 +146,7 @@ export const Enhance = (state: State, opts: PluginOpts): State => {
         ctx: state.ctx,
         data: pluginState.data,
         game: opts.game,
+        playerID: opts.playerID,
       });
 
       state = {

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -10,6 +10,7 @@ import PluginImmer from './plugin-immer';
 import PluginRandom from './plugin-random';
 import PluginEvents from './plugin-events';
 import {
+  AnyFn,
   PartialGameState,
   State,
   GameConfig,
@@ -88,8 +89,8 @@ export const EnhanceCtx = (state: PartialGameState): Ctx => {
  * @param {function} fn - The move function or trigger to apply the plugins to.
  * @param {object} plugins - The list of plugins.
  */
-export const FnWrap = (fn: (...args: any[]) => any, plugins: Plugin[]) => {
-  const reducer = (acc, { fnWrap }) => fnWrap(acc, plugins);
+export const FnWrap = (fn: AnyFn, plugins: Plugin[]) => {
+  const reducer = (acc: AnyFn, { fnWrap }: Plugin) => fnWrap(acc);
   return [...DEFAULT_PLUGINS, ...plugins]
     .filter(plugin => plugin.fnWrap !== undefined)
     .reduce(reducer, fn);

--- a/src/plugins/main.ts
+++ b/src/plugins/main.ts
@@ -184,8 +184,8 @@ export const Flush = (state: State, opts: PluginOpts): State => {
           [plugin.name]: { data: newData },
         },
       };
-    } else if (plugin.flushRaw) {
-      state = plugin.flushRaw({
+    } else if (plugin.dangerouslyFlushRawState) {
+      state = plugin.dangerouslyFlushRawState({
         state,
         game: opts.game,
         api: pluginState.api,

--- a/src/plugins/plugin-events.ts
+++ b/src/plugins/plugin-events.ts
@@ -18,7 +18,7 @@ const EventsPlugin: Plugin<EventsAPI & PrivateEventsAPI> = {
     return api._obj.isUsed();
   },
 
-  flushRaw: ({ state, api }) => {
+  dangerouslyFlushRawState: ({ state, api }) => {
     return api._obj.update(state);
   },
 

--- a/src/plugins/plugin-events.ts
+++ b/src/plugins/plugin-events.ts
@@ -6,26 +6,10 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { Plugin, State } from '../types';
-import { Events } from './events/events';
+import { Plugin } from '../types';
+import { Events, EventsAPI, PrivateEventsAPI } from './events/events';
 
-export interface EventsAPI {
-  endGame?(...args: any[]): void;
-  endPhase?(...args: any[]): void;
-  endStage?(...args: any[]): void;
-  endTurn?(...args: any[]): void;
-  pass?(...args: any[]): void;
-  setActivePlayers?(...args: any[]): void;
-  setPhase?(...args: any[]): void;
-  setStage?(...args: any[]): void;
-}
-
-interface PrivateEventsAPI {
-  _obj: {
-    isUsed(): boolean;
-    update(state: State): State;
-  };
-}
+export { EventsAPI };
 
 const EventsPlugin: Plugin<EventsAPI & PrivateEventsAPI> = {
   name: 'events',

--- a/src/plugins/plugin-events.ts
+++ b/src/plugins/plugin-events.ts
@@ -6,6 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
+import { Plugin, State } from '../types';
 import { Events } from './events/events';
 
 export interface EventsAPI {
@@ -19,7 +20,14 @@ export interface EventsAPI {
   setStage?(...args: any[]): void;
 }
 
-export default {
+interface PrivateEventsAPI {
+  _obj: {
+    isUsed(): boolean;
+    update(state: State): State;
+  };
+}
+
+const EventsPlugin: Plugin<EventsAPI & PrivateEventsAPI> = {
   name: 'events',
 
   noClient: ({ api }) => {
@@ -34,3 +42,5 @@ export default {
     return new Events(game.flow, playerID).api(ctx);
   },
 };
+
+export default EventsPlugin;

--- a/src/plugins/plugin-immer.ts
+++ b/src/plugins/plugin-immer.ts
@@ -7,12 +7,15 @@
  */
 
 import produce from 'immer';
+import { Plugin } from '../types';
 
 /**
  * Plugin that allows using Immer to make immutable changes
  * to G by just mutating it.
  */
-export default {
+const ImmerPlugin: Plugin = {
   name: 'plugin-immer',
   fnWrap: move => produce(move),
 };
+
+export default ImmerPlugin;

--- a/src/plugins/plugin-player.ts
+++ b/src/plugins/plugin-player.ts
@@ -6,10 +6,14 @@
  * https://opensource.org/licenses/MIT.
  */
 
+import { Plugin, PlayerID } from '../types';
+
+interface PlayerData {
+  players: Record<PlayerID, any>;
+}
+
 export interface PlayerAPI {
-  state: {
-    [playerId: string]: object;
-  };
+  state: Record<PlayerID, any>;
   get(): any;
   set(value: any): any;
   opponent?: {
@@ -25,7 +29,7 @@ export interface PlayerAPI {
  *
  * @param {function} initPlayerState - Function of type (playerID) => playerState.
  */
-export default {
+const PlayerPlugin: Plugin<PlayerAPI, PlayerData> = {
   name: 'player',
 
   flush: ({ api }) => {
@@ -60,9 +64,9 @@ export default {
   },
 
   setup: ({ ctx, game }) => {
-    let players = {};
+    let players: Record<PlayerID, any> = {};
     for (let i = 0; i < ctx.numPlayers; i++) {
-      let playerState = {};
+      let playerState: any = {};
       if (game.playerSetup !== undefined) {
         playerState = game.playerSetup(i + '');
       }
@@ -71,3 +75,5 @@ export default {
     return { players };
   },
 };
+
+export default PlayerPlugin;

--- a/src/plugins/plugin-random.ts
+++ b/src/plugins/plugin-random.ts
@@ -6,6 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
+import { Plugin } from '../types';
 import { Random } from './random/random';
 
 export interface RandomAPI {
@@ -25,7 +26,14 @@ export interface RandomAPI {
   Shuffle<T>(deck: T[]): T[];
 }
 
-export default {
+interface PrivateRandomAPI {
+  _obj: {
+    isUsed(): boolean;
+    getState(): any;
+  };
+}
+
+const RandomPlugin: Plugin<RandomAPI & PrivateRandomAPI> = {
   name: 'random',
 
   noClient: ({ api }) => {
@@ -49,3 +57,5 @@ export default {
     return { seed };
   },
 };
+
+export default RandomPlugin;

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,13 @@ export interface Plugin<API extends any = any, Data extends any = any> {
   noClient?: (context: PluginContext<API, Data>) => boolean;
   setup?: (setupCtx: { G: any; ctx: Ctx; game: GameConfig }) => Data;
   action?: (data: Data, payload: ActionShape.Plugin['payload']) => Data;
-  api?: (context: { G: any; ctx: Ctx; game: GameConfig; data: Data }) => API;
+  api?: (context: {
+    G: any;
+    ctx: Ctx;
+    game: GameConfig;
+    data: Data;
+    playerID?: PlayerID;
+  }) => API;
   flush?: (context: PluginContext<API, Data>) => Data;
   flushRaw?: (flushCtx: {
     state: State;

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,7 +92,7 @@ export interface Plugin<API extends any = any, Data extends any = any> {
     playerID?: PlayerID;
   }) => API;
   flush?: (context: PluginContext<API, Data>) => Data;
-  flushRaw?: (flushCtx: {
+  dangerouslyFlushRawState?: (flushCtx: {
     state: State;
     game: GameConfig;
     api: API;


### PR DESCRIPTION
I used the `Plugin` type to enforce the type of the bundled plugins and that revealed some inconsistencies between the typing and the implementations, which I’ve tried to iron out.

- The events plugin expects a player ID to initialise its API, but the `Enhance` method didn’t receive or pass a player ID.

    https://github.com/nicolodavis/boardgame.io/blob/9046ad1120a86bef6f25e6d32a9cc6021b2a9cbe/src/plugins/plugin-events.ts#L33-L35
    https://github.com/nicolodavis/boardgame.io/blob/9046ad1120a86bef6f25e6d32a9cc6021b2a9cbe/src/plugins/main.ts#L139-L144

    I’m not sure, but I wonder if this might explain #570, because the automatic game events might not function correctly if the events code isn’t receiving a player ID.

    I’ve added `playerID` to the `Enhance` call sites, but it will be undefined when called while the game is being initialised because there is no `playerID` at that point.

- Typing the plugin fields completely will make `flushRaw` a little more visible to Typescript users, so I’ve renamed it to `dangerouslyFlushRawState` to try and make it clearer that it isn’t a recommended method to use.

- The `Plugin` type should now fully reflect the Plugin API and I’ve also updated the Plugins doc to better match this.