### PR TITLE
docs(storage): Document bgio-storage-cache module

### DIFF
--- a/docs/documentation/storage.md
+++ b/docs/documentation/storage.md
@@ -47,6 +47,13 @@ Coming soon.
 Coming soon (used to be supported but is not in sync with the
 latest release).
 
+### Caching
+
+Depending on your set-up, you may want the server to cache some of the data,
+reducing the load on your database and speeding up server responses.
+[bgio-storage-cache](https://github.com/delucis/bgio-storage-cache) offers
+a basic caching model compatible with any boardgame.io database connector.
+
 ### Writing a Custom Adapter
 
 Create a class that implements the [StorageAPI.Async](https://github.com/nicolodavis/boardgame.io/blob/master/src/server/db/base.ts) interface.

--- a/docs/documentation/storage.md
+++ b/docs/documentation/storage.md
@@ -34,15 +34,17 @@ const server = Server({
 server.run(8000);
 ```
 
-### Firebase
+### Other backends
+
+#### Firebase
 
 Instructions at https://github.com/delucis/bgio-firebase.
 
-### Postgres
+#### Postgres
 
 Coming soon.
 
-### MongoDB
+#### MongoDB
 
 Coming soon (used to be supported but is not in sync with the
 latest release).


### PR DESCRIPTION
Adds a “caching” section to the storage docs, linking to `bgio-storage-cache`.