### PR TITLE
add documentation on WrappedBoard's missing `credentials` prop

### DIFF
--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -17,7 +17,9 @@ The component supports the following `props`:
 
 2. `playerID`: Associate the client with a player (multiplayer).
 
-3. `debug`: Set to `false` to disable the Debug UI.
+3. `credentials`: The `playerID`s authentication credentials (multiplayer).
+
+4. `debug`: Set to `false` to disable the Debug UI.
 
 ### Usage
 


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [] Test coverage is 100% (or you have a story for why it's ok).

I found the [credentials prop](https://github.com/nicolodavis/boardgame.io/blob/78729ebe9425a79ce65d76d1ae72211f8a17e726/src/client/react.js#L58) of the `WrappedBoard` react component returned by the Client not to be mentioned in the docs.