### PR TITLE
Specify type of parameters when joining game

### DIFF
--- a/docs/documentation/api/Lobby.md
+++ b/docs/documentation/api/Lobby.md
@@ -66,7 +66,7 @@ Returns `roomID`, which is the ID of the newly created game instance.
 
 Allows a player to join a particular room instance `id` of a game named `name`.
 
-Accepts two parameters, all required:
+Accepts two JSON body parameters, all required:
 
 `playerID`: the ordinal player in the game that is being joined (0, 1...).
 


### PR DESCRIPTION
This will save time for many users when building their games.
Other Lobby API's are using query parameters, while this one is using body params.
This was confusing.

#### Checklist

* [ ] Use a separate branch in your local repo (not `master`).
* [ ] Test coverage is 100% (or you have a story for why it's ok).
