### PR TITLE
fix(core): Don’t error if turn.order.next returns undefined

### DIFF
--- a/src/core/turn-order.ts
+++ b/src/core/turn-order.ts
@@ -291,7 +291,7 @@ export function UpdateTurnOrderState(
     const type = typeof t;
     if (t !== undefined && type !== 'number') {
       logging.error(
-        `invalid value returned by turn.order.next — expected number got ${type} “${t}”.`
+        `invalid value returned by turn.order.next — expected number or undefined, got ${type} “${t}”.`
       );
     }
 

--- a/src/core/turn-order.ts
+++ b/src/core/turn-order.ts
@@ -289,7 +289,7 @@ export function UpdateTurnOrderState(
   } else {
     const t = order.next(G, ctx);
     const type = typeof t;
-    if (type !== 'number') {
+    if (t !== undefined && type !== 'number') {
       logging.error(
         `invalid value returned by turn.order.next — expected number got ${type} “${t}”.`
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,7 +159,7 @@ export interface StageMap {
 
 export interface TurnOrderConfig {
   first: (G: any, ctx: Ctx) => number;
-  next: (G: any, ctx: Ctx) => number;
+  next: (G: any, ctx: Ctx) => number | undefined;
   playOrder?: (G: any, ctx: Ctx) => PlayerID[];
 }
 


### PR DESCRIPTION
Fixes a bug raised by @flamecoals in #605 where an error is logged if `turn.order.next` returns undefined, which is permitted as a way of ending the phase.

I’ve also amended the turn order interface to indicate that `next` can return undefined.