### PR TITLE
build(server): Proxy server module with package.json

### DIFF
--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -11,4 +11,4 @@ const subpackages = require('../subpackages');
 
 shell.rm('-rf', 'dist');
 shell.rm('-rf', subpackages);
-shell.rm('server.js');
+shell.rm('-rf', 'server');

--- a/scripts/proxy-dirs.js
+++ b/scripts/proxy-dirs.js
@@ -10,18 +10,15 @@ const subpackages = require('../subpackages');
 const path = require('path');
 const { mkdirSync, writeFileSync } = require('fs');
 
-function PackageJson(
-  name,
-  { mainDir = '../dist/cjs', includeModuleField = true } = {}
-) {
+function PackageJson(name, { mainDir, esmDir } = {}) {
   const pkg = {
     name: `boardgame.io/${name}`,
     private: true,
     types: `../dist/types/packages/${name}.d.ts`,
-    main: `${mainDir}/${name}.js`,
+    main: path.join(mainDir, `${name}.js`),
   };
-  if (includeModuleField) {
-    pkg.module = `../dist/esm/${name}.js`;
+  if (esmDir) {
+    pkg.module = path.join(esmDir, `${name}.js`);
   }
   return JSON.stringify(pkg, null, 2) + '\n';
 }
@@ -32,5 +29,8 @@ function makeSubpackage(name, opts) {
   writeFileSync(`${dir}/package.json`, PackageJson(name, opts));
 }
 
-subpackages.forEach(name => makeSubpackage(name));
-makeSubpackage('server', { mainDir: '../dist', includeModuleField: false });
+subpackages.forEach(name => {
+  makeSubpackage(name, { mainDir: '../dist/cjs', esmDir: '../dist/esm' });
+});
+
+makeSubpackage('server', { mainDir: '../dist' });

--- a/scripts/proxy-dirs.js
+++ b/scripts/proxy-dirs.js
@@ -10,24 +10,27 @@ const subpackages = require('../subpackages');
 const path = require('path');
 const { mkdirSync, writeFileSync } = require('fs');
 
-function PackageJson(name) {
-  return `{
-  "name": "boardgame.io/${name}",
-  "private": true,
-  "types": "../dist/types/packages/${name}.d.ts",
-  "main": "../dist/cjs/${name}.js",
-  "module": "../dist/esm/${name}.js"
-}
-`;
+function PackageJson(
+  name,
+  { mainDir = '../dist/cjs', includeModuleField = true } = {}
+) {
+  const package = {
+    name: `boardgame.io/${name}`,
+    private: true,
+    types: `../dist/types/packages/${name}.d.ts`,
+    main: `${mainDir}/${name}.js`,
+  };
+  if (includeModuleField) {
+    package.module = `../dist/esm/${name}.js`;
+  }
+  return JSON.stringify(package, null, 2) + '\n';
 }
 
-subpackages.forEach(name => {
+function makeSubpackage(name, opts) {
   const dir = path.resolve(__dirname, `../${name}`);
   mkdirSync(dir);
-  writeFileSync(`${dir}/package.json`, PackageJson(name));
-});
+  writeFileSync(`${dir}/package.json`, PackageJson(name, opts));
+}
 
-writeFileSync(
-  path.resolve(__dirname, '../server.js'),
-  "module.exports = require('./dist/server');"
-);
+subpackages.forEach(name => makeSubpackage(name));
+makeSubpackage('server', { mainDir: '../dist', includeModuleField: false });

--- a/scripts/proxy-dirs.js
+++ b/scripts/proxy-dirs.js
@@ -14,16 +14,16 @@ function PackageJson(
   name,
   { mainDir = '../dist/cjs', includeModuleField = true } = {}
 ) {
-  const package = {
+  const pkg = {
     name: `boardgame.io/${name}`,
     private: true,
     types: `../dist/types/packages/${name}.d.ts`,
     main: `${mainDir}/${name}.js`,
   };
   if (includeModuleField) {
-    package.module = `../dist/esm/${name}.js`;
+    pkg.module = `../dist/esm/${name}.js`;
   }
-  return JSON.stringify(package, null, 2) + '\n';
+  return JSON.stringify(pkg, null, 2) + '\n';
 }
 
 function makeSubpackage(name, opts) {


### PR DESCRIPTION
Mirrors how the other subpackages are bundled by exposing `boardgame.io/server` via a directory with a package.json that includes a pointer to the main entrypoint and the server type definitions. Addresses issues discussed in #576 and https://github.com/nicolodavis/boardgame.io/issues/190#issuecomment-612862456.

(I’ve also refactored the `proxy-dirs` code quite a bit, so feel free to pull me up on that if there’s something you’d prefer done in another way.)