### PR TITLE
Adjust new deployment doc by adding necessary npm packages

### DIFF
--- a/docs/documentation/deployment.md
+++ b/docs/documentation/deployment.md
@@ -8,7 +8,7 @@ Below is an example of how to achieve that.
 First install these extra dependencies: 
 
 ```
-npm i koa-static koa-mount -S
+npm i --save koa-static koa-mount
 ```
 Then adjust your `server.js` file like this:
 

--- a/docs/documentation/deployment.md
+++ b/docs/documentation/deployment.md
@@ -35,6 +35,12 @@ server.run(PORT, () => {
 });
 ``` 
 
+Install `koa-static` and `koa-mount`
+
+```
+npm i koa-static koa-mount
+```
+
 The [Lobby](/api/Lobby.md) might be as follows:
 
 ```jsx

--- a/docs/documentation/deployment.md
+++ b/docs/documentation/deployment.md
@@ -5,6 +5,13 @@
 In order to deploy a game to [Heroku](heroku.com), the game has to be running on a single port. To do so, the [Server](/api/Server.md) has to handle both the API requests and serving the pages.  
 Below is an example of how to achieve that.
 
+First install these extra dependencies: 
+
+```
+npm i koa-static koa-mount -S
+```
+Then adjust your `server.js` file like this:
+
 ```js
 // server.js
 
@@ -34,12 +41,6 @@ server.run(PORT, () => {
   )
 });
 ``` 
-
-Install `koa-static` and `koa-mount`
-
-```
-npm i koa-static koa-mount
-```
 
 The [Lobby](/api/Lobby.md) might be as follows:
 


### PR DESCRIPTION
Tried the new method of deployment described in the `deployment` document, but it failed at first - I had to explicitly install `koa-static` and `koa-mount` packages to make it happen.