### PR TITLE
Adding playerID to Ctx

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface Ctx {
   numPlayers: number;
   playOrder: Array<PlayerID>;
   playOrderPos: number;
+  playerID?: PlayerID;
   activePlayers: null | ActivePlayers;
   currentPlayer: PlayerID;
   numMoves?: number;


### PR DESCRIPTION
This is available and used in several games on FBG right now:

https://github.com/freeboardgames/FreeBoardGames.org/blob/df037cc12e21948acfb63a90e6dd4cb088851ea4/src/games/takesix/game.ts#L50
https://github.com/freeboardgames/FreeBoardGames.org/blob/6317daad1079430257dc2648b85c61e393a071fd/src/games/secretcodes/util.ts#L11

It is especially important for knowing which user played when multiple users can play in the same turn (the currentPlayer in that case does not mean much)

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
