### PR TITLE
Fix link to roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Please use the [Issue Tracker](https://github.com/nicolodavis/boardgame.io/issues) to discuss
 potential improvements you want to make before sending a Pull Request.
-The [roadmap](docs/roadmap.md) is probably the best place to find areas where help would
+The [roadmap](roadmap.md) is probably the best place to find areas where help would
 most be appreciated.
 
 The Issue Tracker may contain items labelled **help wanted** or **good first issue**


### PR DESCRIPTION
In d463b00 the roadmap file was moved to the top level of the repository. However, the link to the roadmap in the contribution guide wasn't updated. This commit fixes the link and ensures that the roadmap document is easily accessible from the contribution guide.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
