### PR TITLE
Add option to run server over HTTPS

### DIFF
--- a/docs/documentation/api/Server.md
+++ b/docs/documentation/api/Server.md
@@ -62,6 +62,24 @@ server.run(8000);
 server.run(8000, () => console.log("server running..."));
 ```
 
+##### With HTTPS
+
+```js
+const { Server } = require('boardgame.io/server');
+const fs = require('fs');
+
+const server = Server({
+  games: [game1, game2, ...],
+
+  https: {
+    cert: fs.readFileSync('/path/to/cert'),
+    key: fs.readFileSync('/path/to/key'),
+  },
+});
+
+server.run(8000);
+```
+
 ##### With custom authentication
 
 `generateCredentials` is called when a player joins a game with:

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -26,6 +26,11 @@ interface ServerConfig {
   };
 }
 
+interface HttpsOptions {
+  cert: string;
+  key: string;
+}
+
 /**
  * Build config object from server run arguments.
  */
@@ -59,6 +64,7 @@ interface ServerOpts {
   transport?;
   authenticateCredentials?: ServerTypes.AuthenticateCredentials;
   generateCredentials?: ServerTypes.GenerateCredentials;
+  https?: HttpsOptions;
 }
 
 /**
@@ -69,6 +75,7 @@ interface ServerOpts {
  * @param transport - The interface with the clients.
  * @param authenticateCredentials - Function to test player credentials.
  * @param generateCredentials - Method for API to generate player credentials.
+ * @param https - HTTPS configuration options passed through to the TLS module.
  */
 export function Server({
   games,
@@ -76,6 +83,7 @@ export function Server({
   transport,
   authenticateCredentials,
   generateCredentials,
+  https,
 }: ServerOpts) {
   const app = new Koa();
 
@@ -91,7 +99,10 @@ export function Server({
       typeof authenticateCredentials === 'function'
         ? authenticateCredentials
         : true;
-    transport = SocketIO({ auth });
+    transport = SocketIO({
+      auth,
+      https,
+    });
   }
   transport.init(app, games);
 

--- a/src/server/transport/socketio.js
+++ b/src/server/transport/socketio.js
@@ -62,6 +62,7 @@ export function SocketIO({
   clientInfo = new Map(),
   roomInfo = new Map(),
   auth = true,
+  https,
 } = {}) {
   return {
     init: (app, games) => {
@@ -73,7 +74,7 @@ export function SocketIO({
       });
 
       app.context.io = io;
-      io.attach(app);
+      io.attach(app, !!https, https);
 
       for (const game of games) {
         const nsp = app._io.of(game.name);


### PR DESCRIPTION
This commit adds the option to run the boardgame.io server over HTTPS by passing through [koa-socket-2 SSL options](https://github.com/ambelovsky/koa-socket-2/blob/3c4433e/README.md#https-example) to the SocketIO transport.

While it's also possible to achieve HTTPS in other ways, e.g. via nginx as discussed in https://github.com/nicolodavis/boardgame.io/issues/322, enabling first-party support for HTTPS makes it much simpler to spin up such services since it removes the need to install and configure an external SSL terminator and proxy.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
