### PR TITLE
feat(core): Support moves that don’t contribute to numMoves

### DIFF
--- a/docs/documentation/api/Game.md
+++ b/docs/documentation/api/Game.md
@@ -20,6 +20,7 @@
       undoable: false,  // prevents undoing the move.
       redact: true,     // prevents the move arguments from showing up in the log.
       client: false,    // prevents the move from running on the client.
+      noLimit: true,    // prevents the move counting towards a player’s number of moves.
     },
   },
 

--- a/src/core/flow.test.js
+++ b/src/core/flow.test.js
@@ -308,6 +308,33 @@ describe('turn', () => {
       expect(state.ctx.turn).toBe(4);
       expect(state.ctx.currentPlayer).toBe('1');
     });
+
+    test('with noLimit moves', () => {
+      const flow = Flow({
+        turn: {
+          moveLimit: 2,
+        },
+        moves: {
+          A: () => {},
+          B: {
+            move: () => {},
+            noLimit: true,
+          },
+        },
+      });
+      let state = flow.init({ ctx: flow.ctx(2) });
+      expect(state.ctx.turn).toBe(1);
+      expect(state.ctx.numMoves).toBe(0);
+      state = flow.processMove(state, makeMove('A', null, '0').payload);
+      expect(state.ctx.turn).toBe(1);
+      expect(state.ctx.numMoves).toBe(1);
+      state = flow.processMove(state, makeMove('B', null, '0').payload);
+      expect(state.ctx.turn).toBe(1);
+      expect(state.ctx.numMoves).toBe(1);
+      state = flow.processMove(state, makeMove('A', null, '0').payload);
+      expect(state.ctx.turn).toBe(2);
+      expect(state.ctx.numMoves).toBe(0);
+    });
   });
 
   describe('endIf', () => {

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -663,17 +663,21 @@ export function Flow({
 
   function ProcessMove(state: State, action: ActionPayload.MakeMove): State {
     let conf = GetPhase(state.ctx);
+    const move = GetMove(state.ctx, action.type, action.playerID);
+    const shouldCount =
+      !move || typeof move === 'function' || move.noLimit !== true;
 
     let { ctx } = state;
     let { _activePlayersNumMoves } = ctx;
 
     const { playerID } = action;
 
-    if (ctx.activePlayers) _activePlayersNumMoves[playerID]++;
-
     let numMoves = state.ctx.numMoves;
-    if (playerID == state.ctx.currentPlayer) {
-      numMoves++;
+    if (shouldCount) {
+      if (playerID == state.ctx.currentPlayer) {
+        numMoves++;
+      }
+      if (ctx.activePlayers) _activePlayersNumMoves[playerID]++;
     }
 
     state = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,7 @@ export interface LongFormMove<
 > {
   move: MoveFn<G, CtxWithPlugins>;
   redact?: boolean;
+  noLimit?: boolean;
   client?: boolean;
   undoable?: boolean | ((G: G, ctx: CtxWithPlugins) => boolean);
 }


### PR DESCRIPTION
This implements a long-form move syntax that prevents a move from incrementing `numMoves` and by extension triggering move limits. It would close #644.

This is a slightly naïve way of implementing this `noLimit` feature because as a consequence we completely lose track of those moves in the move counts. In theory we could track `numMoves` and `limitNumMoves` separately and trigger move limits using the latter, but it would make state and logic more complex. Let me know if you think it’s acceptable as is or if we should implement the more robust version.