### PR TITLE
feat(server): Add option to exclude rooms from public listing

### DIFF
--- a/docs/documentation/api/Lobby.md
+++ b/docs/documentation/api/Lobby.md
@@ -52,11 +52,13 @@ Options are:
 
 Creates a new authenticated room for a game named `name`.
 
-Accepts two parameters:
+Accepts three parameters:
 
 `numPlayers` (required): the number of players.
 
 `setupData` (optional): custom object that is passed to the game `setup` function.
+
+`unlisted` (optional): if set to `true`, the room will be excluded from the public list of room instances.
 
 Returns `roomID`, which is the ID of the newly created game instance.
 

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -96,6 +96,7 @@ describe('.createApiServer', () => {
                 '1': 'red',
               },
             },
+            unlisted: true,
           });
       });
 
@@ -142,6 +143,7 @@ describe('.createApiServer', () => {
                 '1': 'red',
               }),
             }),
+            unlisted: true,
           })
         );
       });
@@ -1041,7 +1043,7 @@ describe('.createApiServer', () => {
     beforeEach(() => {
       delete process.env.API_SECRET;
       db = new AsyncStorage({
-        fetch: async () => {
+        fetch: async gameID => {
           return {
             metadata: {
               players: {
@@ -1054,6 +1056,7 @@ describe('.createApiServer', () => {
                   credentials: 'SECRET2',
                 },
               },
+              unlisted: gameID === 'bar-4',
             },
           };
         },
@@ -1063,6 +1066,7 @@ describe('.createApiServer', () => {
             'foo-1': { gameName: 'foo' },
             'bar-2': { gameName: 'bar' },
             'bar-3': { gameName: 'bar' },
+            'bar-4': { gameName: 'bar' },
           };
           const keys = Object.keys(metadata);
           if (opts && opts.gameName) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,6 +278,7 @@ export namespace Server {
     setupData: any;
     gameover?: any;
     nextRoomID?: string;
+    unlisted?: boolean;
   }
 
   export interface LobbyConfig {


### PR DESCRIPTION
This commit adds an option to game room creation to mark the room as unlisted. Unlisted rooms are excluded from the list of all rooms. The setting is useful for situations where someone wants to host a room for friends and therefore doesn't want arbitrary people to be able to join their room via the lobby.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
