### PR TITLE
Use `/update` endpoint in unit tests instead of deprecated `/rename`.

### DIFF
--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -388,7 +388,7 @@ describe('.createApiServer', () => {
           });
           const app = createApiServer({ db, games });
           response = await request(app.callback())
-            .post('/games/foo/1/rename')
+            .post('/games/foo/1/update')
             .send('playerID=0&playerName=alice&newName=ali');
           expect(response.status).toEqual(404);
         });
@@ -417,7 +417,7 @@ describe('.createApiServer', () => {
             });
             const app = createApiServer({ db, games });
             response = await request(app.callback())
-              .post('/games/foo/1/rename')
+              .post('/games/foo/1/update')
               .send('playerID=0&credentials=SECRET1&newName=ali');
           });
 
@@ -425,7 +425,7 @@ describe('.createApiServer', () => {
             test('throws newName must be a string', async () => {
               const app = createApiServer({ db, games });
               response = await request(app.callback())
-                .post('/games/foo/1/rename')
+                .post('/games/foo/1/update')
                 .send({ playerID: 0, credentials: 'SECRET1', newName: 2 });
               expect(response.text).toEqual(
                 'newName must be a string, got number'
@@ -455,7 +455,7 @@ describe('.createApiServer', () => {
           test('throws error 404', async () => {
             const app = createApiServer({ db, games });
             response = await request(app.callback())
-              .post('/games/foo/1/rename')
+              .post('/games/foo/1/update')
               .send('playerID=2&credentials=SECRET1&newName=joe');
             expect(response.status).toEqual(404);
           });
@@ -465,7 +465,7 @@ describe('.createApiServer', () => {
           test('throws error 404', async () => {
             const app = createApiServer({ db, games });
             response = await request(app.callback())
-              .post('/games/foo/1/rename')
+              .post('/games/foo/1/update')
               .send('playerID=0&credentials=SECRET2&newName=mike');
             expect(response.status).toEqual(403);
           });
@@ -474,7 +474,7 @@ describe('.createApiServer', () => {
           beforeEach(async () => {
             const app = createApiServer({ db, games });
             response = await request(app.callback())
-              .post('/games/foo/1/rename')
+              .post('/games/foo/1/update')
               .send('credentials=foo&newName=bill');
           });
 
@@ -485,7 +485,7 @@ describe('.createApiServer', () => {
             beforeEach(async () => {
               const app = createApiServer({ db, games });
               response = await request(app.callback())
-                .post('/games/foo/1/rename')
+                .post('/games/foo/1/update')
                 .send('credentials=foo&playerID=0');
             });
 


### PR DESCRIPTION
This is trivial, it just removes some warnings when running tests, following the recent renaming of the `/rename` Lobby endpoint to `/update` in #642.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
