### PR TITLE
[Documentation] Remove references to removed MongoDB adapter

### DIFF
--- a/docs/documentation/multiplayer.md
+++ b/docs/documentation/multiplayer.md
@@ -218,22 +218,6 @@ either by a URL path or a lobby implementation.
 The default storage implementation is an in-memory map.
 If you want something that's more persistent, you can use one
 of the bundled connectors for various backends, or even implement
-your own connector. For example, here is how you can keep your
-game state in a MongoDB.
-
-```js
-const { Server, Mongo } = require('boardgame.io/server');
-const { TicTacToe } = require('./game');
-
-const server = Server({
-  games: [TicTacToe],
-  db: new Mongo({
-    url: 'mongodb://...',
-    dbname: 'bgio',
-  }),
-});
-
-server.run(8000);
-```
+your own connector.
 
 See [here](storage.md) for more details about how to customize storage.


### PR DESCRIPTION
The MongoDB adapter was removed relatively recently from the project, but the multiplayer documentation implies that it still exists.

This PR removes that part from the docs. 