### PR TITLE
fix(api): Expose gameover metadata in rooms endpoints.

### DIFF
--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -1137,6 +1137,7 @@ describe('.createApiServer', () => {
                 },
               },
               unlisted: gameID === 'bar-4',
+              gameover: gameID === 'bar-3' ? { winner: 0 } : undefined,
             },
           };
         },
@@ -1156,6 +1157,7 @@ describe('.createApiServer', () => {
         },
       });
     });
+
     describe('when given 2 rooms', () => {
       let response;
       let rooms;
@@ -1179,6 +1181,11 @@ describe('.createApiServer', () => {
         expect(rooms[0].players).toEqual([{ id: 0 }, { id: 1 }]);
         expect(rooms[1].players).toEqual([{ id: 0 }, { id: 1 }]);
       });
+
+      test('returns gameover data for ended game', async () => {
+        expect(rooms[0].gameover).toBeUndefined();
+        expect(rooms[1].gameover).toEqual({ winner: 0 });
+      });
     });
   });
 
@@ -1200,6 +1207,7 @@ describe('.createApiServer', () => {
                   credentials: 'SECRET2',
                 },
               },
+              gameover: { winner: 1 },
             },
           };
         },
@@ -1225,6 +1233,10 @@ describe('.createApiServer', () => {
 
       test('returns player names', async () => {
         expect(room.players).toEqual([{ id: 0 }, { id: 1 }]);
+      });
+
+      test('returns gameover data for ended game', async () => {
+        expect(room.gameover).toEqual({ winner: 1 });
       });
     });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -139,6 +139,7 @@ export const addApiToServer = ({
             return strippedInfo;
           }),
           setupData: metadata.setupData,
+          gameover: metadata.gameover,
         });
       }
     }
@@ -162,6 +163,7 @@ export const addApiToServer = ({
         return strippedInfo;
       }),
       setupData: metadata.setupData,
+      gameover: metadata.gameover,
     };
     ctx.body = strippedRoom;
   });


### PR DESCRIPTION
This adds the `gameover` metadata, if it exists, to both the all rooms and single room query endpoints.

Fixes #665.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
