### PR TITLE
docs(phases): Expand documentation of phase.endIf

### DIFF
--- a/docs/documentation/phases.md
+++ b/docs/documentation/phases.md
@@ -148,17 +148,48 @@ authoritative game state.
 
 #### Moving between Phases
 
+##### Using events
+
 The two primary ways of moving between phases are by calling the
 following events:
 
 1. `endPhase`: This ends the current phase and returns the game
    to a state where no phase is active. If the phase specifies a
    `next` option, then the game will move into that phase instead.
-   This event can also be triggered automatically by using an `endIf`
-   condition in the phase spec.
 
 2. `setPhase`: This ends the current phase and moves the game into
    the phase specified by the argument.
+
+
+##### Using an `endIf` condition
+
+You can also end a phase by returning a truthy value from its
+`endIf` method:
+
+```js
+phases: {
+  phaseA: {
+    next: 'phaseB',
+    endIf: (G, ctx) => true,
+  },
+  phaseB: { ... },
+},
+```
+
+If you need to specify the next phase dynamically, you can return
+an object containing a `next` field from your `endIf`:
+
+```js
+phases: {
+  phaseA: {
+    endIf: (G, ctx) => {
+      return { next: G.condition ? 'phaseB' : 'phaseC' }
+    },
+  },
+  phaseB: { ... },
+  phaseC: { ... },
+},
+```
 
 !> Whenever a phase ends, the current player's turn is first ended automatically.
 

--- a/src/core/flow.ts
+++ b/src/core/flow.ts
@@ -399,12 +399,12 @@ export function Flow({
     return wrapped.endIf(state);
   }
 
-  function ShouldEndPhase(state: State): boolean | void {
+  function ShouldEndPhase(state: State): boolean | void | { next: string } {
     const conf = GetPhase(state.ctx);
     return conf.wrapped.endIf(state);
   }
 
-  function ShouldEndTurn(state: State): boolean | void {
+  function ShouldEndTurn(state: State): boolean | void | { next: PlayerID } {
     const conf = GetPhase(state.ctx);
 
     // End the turn if the required number of moves has been made.

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,11 +162,13 @@ export interface PhaseConfig<
   next?: string;
   onBegin?: (G: G, ctx: CtxWithPlugins) => any;
   onEnd?: (G: G, ctx: CtxWithPlugins) => any;
-  endIf?: (G: G, ctx: CtxWithPlugins) => boolean | void;
+  endIf?: (G: G, ctx: CtxWithPlugins) => boolean | void | { next: string };
   moves?: MoveMap<G, CtxWithPlugins>;
   turn?: TurnConfig<G, CtxWithPlugins>;
   wrapped?: {
-    endIf?: (state: State<G, CtxWithPlugins>) => boolean | void;
+    endIf?: (
+      state: State<G, CtxWithPlugins>
+    ) => boolean | void | { next: string };
     onBegin?: (state: State<G, CtxWithPlugins>) => any;
     onEnd?: (state: State<G, CtxWithPlugins>) => any;
   };
@@ -204,13 +206,15 @@ export interface TurnConfig<
   moveLimit?: number;
   onBegin?: (G: G, ctx: CtxWithPlugins) => any;
   onEnd?: (G: G, ctx: CtxWithPlugins) => any;
-  endIf?: (G: G, ctx: CtxWithPlugins) => boolean | void;
+  endIf?: (G: G, ctx: CtxWithPlugins) => boolean | void | { next: PlayerID };
   onMove?: (G: G, ctx: CtxWithPlugins) => any;
   stages?: StageMap<G, CtxWithPlugins>;
   moves?: MoveMap<G, CtxWithPlugins>;
   order?: TurnOrderConfig<G, CtxWithPlugins>;
   wrapped?: {
-    endIf?: (state: State<G, CtxWithPlugins>) => boolean | void;
+    endIf?: (
+      state: State<G, CtxWithPlugins>
+    ) => boolean | void | { next: PlayerID };
     onBegin?: (state: State<G, CtxWithPlugins>) => any;
     onEnd?: (state: State<G, CtxWithPlugins>) => any;
     onMove?: (state: State<G, CtxWithPlugins>) => any;


### PR DESCRIPTION
This adds more detail to the “Moving between phases” section of the documentation to clarify how to return a `{ next }` object from a phase’s `endIf`.

I’ve also updated the types to reflect that `endIf` can return `{ next }`.