### PR TITLE
feat(server): Lobby API improvements

### DIFF
--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -95,16 +95,7 @@ describe('.createApiServer', () => {
 
         response = await request(app.callback())
           .post('/games/foo/create')
-          .send({
-            numPlayers: 3,
-            setupData: {
-              colors: {
-                '0': 'green',
-                '1': 'red',
-              },
-            },
-            unlisted: true,
-          });
+          .send({ numPlayers: 3 });
       });
 
       test('is successful', () => {
@@ -126,29 +117,7 @@ describe('.createApiServer', () => {
                 '0': expect.objectContaining({}),
                 '1': expect.objectContaining({}),
               }),
-              setupData: expect.objectContaining({
-                colors: expect.objectContaining({
-                  '0': 'green',
-                  '1': 'red',
-                }),
-              }),
-              unlisted: true,
-            }),
-          })
-        );
-      });
-
-      test('passes arbitrary data to game setup', () => {
-        expect(db.mocks.createGame).toHaveBeenCalledWith(
-          'gameID',
-          expect.objectContaining({
-            initialState: expect.objectContaining({
-              G: expect.objectContaining({
-                colors: {
-                  '0': 'green',
-                  '1': 'red',
-                },
-              }),
+              unlisted: false,
             }),
           })
         );
@@ -184,6 +153,72 @@ describe('.createApiServer', () => {
 
         test('returns 404 error', () => {
           expect(response.status).toEqual(404);
+        });
+      });
+
+      describe('with setupData', () => {
+        beforeEach(async () => {
+          response = await request(app.callback())
+            .post('/games/foo/create')
+            .send({
+              setupData: {
+                colors: {
+                  '0': 'green',
+                  '1': 'red',
+                },
+              },
+            });
+        });
+
+        test('includes setupData in metadata', () => {
+          expect(db.mocks.createGame).toHaveBeenCalledWith(
+            'gameID',
+            expect.objectContaining({
+              metadata: expect.objectContaining({
+                setupData: expect.objectContaining({
+                  colors: expect.objectContaining({
+                    '0': 'green',
+                    '1': 'red',
+                  }),
+                }),
+              }),
+            })
+          );
+        });
+
+        test('passes setupData to game setup function', () => {
+          expect(db.mocks.createGame).toHaveBeenCalledWith(
+            'gameID',
+            expect.objectContaining({
+              initialState: expect.objectContaining({
+                G: expect.objectContaining({
+                  colors: {
+                    '0': 'green',
+                    '1': 'red',
+                  },
+                }),
+              }),
+            })
+          );
+        });
+      });
+
+      describe('with unlisted option', () => {
+        beforeEach(async () => {
+          response = await request(app.callback())
+            .post('/games/foo/create')
+            .send({ unlisted: true });
+        });
+
+        test('sets unlisted in metadata', () => {
+          expect(db.mocks.createGame).toHaveBeenCalledWith(
+            'gameID',
+            expect.objectContaining({
+              metadata: expect.objectContaining({
+                unlisted: true,
+              }),
+            })
+          );
         });
       });
     });

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -176,6 +176,16 @@ describe('.createApiServer', () => {
           );
         });
       });
+
+      describe('for an unknown game name', () => {
+        beforeEach(async () => {
+          response = await request(app.callback()).post('/games/bar/create');
+        });
+
+        test('returns 404 error', () => {
+          expect(response.status).toEqual(404);
+        });
+      });
     });
 
     describe('for a protected lobby', () => {

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -111,46 +111,45 @@ describe('.createApiServer', () => {
         expect(response.status).toEqual(200);
       });
 
-      test('creates game data', () => {
-        expect(db.mocks.setState).toHaveBeenCalledWith(
+      test('creates game state and metadata', () => {
+        expect(db.mocks.createGame).toHaveBeenCalledWith(
           'gameID',
           expect.objectContaining({
-            ctx: expect.objectContaining({
-              numPlayers: 3,
+            initialState: expect.objectContaining({
+              ctx: expect.objectContaining({
+                numPlayers: 3,
+              }),
+            }),
+            metadata: expect.objectContaining({
+              gameName: 'foo',
+              players: expect.objectContaining({
+                '0': expect.objectContaining({}),
+                '1': expect.objectContaining({}),
+              }),
+              setupData: expect.objectContaining({
+                colors: expect.objectContaining({
+                  '0': 'green',
+                  '1': 'red',
+                }),
+              }),
+              unlisted: true,
             }),
           })
         );
       });
 
       test('passes arbitrary data to game setup', () => {
-        expect(db.mocks.setState).toHaveBeenCalledWith(
+        expect(db.mocks.createGame).toHaveBeenCalledWith(
           'gameID',
           expect.objectContaining({
-            G: expect.objectContaining({
-              colors: {
-                '0': 'green',
-                '1': 'red',
-              },
-            }),
-          })
-        );
-      });
-
-      test('creates game metadata', () => {
-        expect(db.mocks.setMetadata).toHaveBeenCalledWith(
-          'gameID',
-          expect.objectContaining({
-            players: expect.objectContaining({
-              '0': expect.objectContaining({}),
-              '1': expect.objectContaining({}),
-            }),
-            setupData: expect.objectContaining({
-              colors: expect.objectContaining({
-                '0': 'green',
-                '1': 'red',
+            initialState: expect.objectContaining({
+              G: expect.objectContaining({
+                colors: {
+                  '0': 'green',
+                  '1': 'red',
+                },
               }),
             }),
-            unlisted: true,
           })
         );
       });
@@ -165,11 +164,13 @@ describe('.createApiServer', () => {
         });
 
         test('uses default numPlayers', () => {
-          expect(db.mocks.setState).toHaveBeenCalledWith(
+          expect(db.mocks.createGame).toHaveBeenCalledWith(
             'gameID',
             expect.objectContaining({
-              ctx: expect.objectContaining({
-                numPlayers: 2,
+              initialState: expect.objectContaining({
+                ctx: expect.objectContaining({
+                  numPlayers: 2,
+                }),
               }),
             })
           );
@@ -973,11 +974,13 @@ describe('.createApiServer', () => {
       response = await request(app.callback())
         .post('/games/foo/1/playAgain')
         .send('playerID=0&credentials=SECRET1&numPlayers=4');
-      expect(db.mocks.setState).toHaveBeenCalledWith(
+      expect(db.mocks.createGame).toHaveBeenCalledWith(
         'newGameID',
         expect.objectContaining({
-          ctx: expect.objectContaining({
-            numPlayers: 4,
+          initialState: expect.objectContaining({
+            ctx: expect.objectContaining({
+              numPlayers: 4,
+            }),
           }),
         })
       );

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -278,7 +278,7 @@ describe('.createApiServer', () => {
             });
             response = await request(app.callback())
               .post('/games/foo/1/join')
-              .send({ playerID: 0, playerName: 'alice', data: 99 });
+              .send({ playerID: 0, playerName: 'alice' });
           });
 
           test('is successful', async () => {
@@ -301,17 +301,27 @@ describe('.createApiServer', () => {
               })
             );
           });
-          test('updates the player data', async () => {
-            expect(db.mocks.setMetadata).toHaveBeenCalledWith(
-              '1',
-              expect.objectContaining({
-                players: expect.objectContaining({
-                  '0': expect.objectContaining({
-                    data: 99,
+
+          describe('when custom data is provided', () => {
+            beforeEach(async () => {
+              const app = createApiServer({ db, games });
+              response = await request(app.callback())
+                .post('/games/foo/1/join')
+                .send({ playerID: 0, playerName: 'alice', data: 99 });
+            });
+
+            test('updates the player data', async () => {
+              expect(db.mocks.setMetadata).toHaveBeenCalledWith(
+                '1',
+                expect.objectContaining({
+                  players: expect.objectContaining({
+                    '0': expect.objectContaining({
+                      data: 99,
+                    }),
                   }),
-                }),
-              })
-            );
+                })
+              );
+            });
           });
         });
 

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -497,6 +497,7 @@ describe('.createApiServer', () => {
             expect(console.warn).toBeCalledWith(warnMsg);
           });
         });
+
         describe('when playerID is omitted', () => {
           beforeEach(async () => {
             const app = createApiServer({ db, games });
@@ -509,19 +510,19 @@ describe('.createApiServer', () => {
             expect(response.status).toEqual(403);
             expect(console.warn).toBeCalledWith(warnMsg);
           });
+        });
 
-          describe('when newName is omitted', () => {
-            beforeEach(async () => {
-              const app = createApiServer({ db, games });
-              response = await request(app.callback())
-                .post('/games/foo/1/rename')
-                .send('credentials=foo&playerID=0');
-            });
+        describe('when newName is omitted', () => {
+          beforeEach(async () => {
+            const app = createApiServer({ db, games });
+            response = await request(app.callback())
+              .post('/games/foo/1/rename')
+              .send('credentials=foo&playerID=0');
+          });
 
-            test('throws error 403', async () => {
-              expect(response.status).toEqual(403);
-              expect(console.warn).toBeCalledWith(warnMsg);
-            });
+          test('throws error 403', async () => {
+            expect(response.status).toEqual(403);
+            expect(console.warn).toBeCalledWith(warnMsg);
           });
         });
       });
@@ -631,6 +632,7 @@ describe('.createApiServer', () => {
             expect(response.text).toEqual('Invalid credentials SECRET2');
           });
         });
+
         describe('when playerID is omitted', () => {
           beforeEach(async () => {
             const app = createApiServer({ db, games });
@@ -641,17 +643,18 @@ describe('.createApiServer', () => {
           test('throws playerID is required', async () => {
             expect(response.text).toEqual('playerID is required');
           });
-          describe('when newName is omitted', () => {
-            beforeEach(async () => {
-              const app = createApiServer({ db, games });
-              response = await request(app.callback())
-                .post('/games/foo/1/update')
-                .send('credentials=foo&playerID=0');
-            });
+        });
 
-            test('throws newName is required', async () => {
-              expect(response.text).toEqual('newName or data is required');
-            });
+        describe('when newName is omitted', () => {
+          beforeEach(async () => {
+            const app = createApiServer({ db, games });
+            response = await request(app.callback())
+              .post('/games/foo/1/update')
+              .send('credentials=foo&playerID=0');
+          });
+
+          test('throws newName is required', async () => {
+            expect(response.text).toEqual('newName or data is required');
           });
         });
       });
@@ -762,6 +765,7 @@ describe('.createApiServer', () => {
             expect(response.text).toEqual('Invalid credentials SECRET2');
           });
         });
+
         describe('when playerID is omitted', () => {
           beforeEach(async () => {
             const app = createApiServer({ db, games });
@@ -773,17 +777,18 @@ describe('.createApiServer', () => {
           test('throws playerID is required', async () => {
             expect(response.text).toEqual('playerID is required');
           });
-          describe('when data is omitted', () => {
-            beforeEach(async () => {
-              const app = createApiServer({ db, games });
-              response = await request(app.callback())
-                .post('/games/foo/1/update')
-                .send({ playerID: 0, credentials: 'foo' });
-            });
+        });
 
-            test('throws data is required', async () => {
-              expect(response.text).toEqual('newName or data is required');
-            });
+        describe('when data is omitted', () => {
+          beforeEach(async () => {
+            const app = createApiServer({ db, games });
+            response = await request(app.callback())
+              .post('/games/foo/1/update')
+              .send({ playerID: 0, credentials: 'foo' });
+          });
+
+          test('throws data is required', async () => {
+            expect(response.text).toEqual('newName or data is required');
           });
         });
       });

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -109,6 +109,8 @@ export const addApiToServer = ({
     let numPlayers = parseInt(ctx.request.body.numPlayers);
 
     const game = games.find(g => g.name === gameName);
+    if (!game) ctx.throw(404, 'Game ' + gameName + ' not found');
+
     const gameID = await CreateGame(
       db,
       game,

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -37,23 +37,20 @@ export const CreateGame = async (
 ) => {
   if (!numPlayers || typeof numPlayers !== 'number') numPlayers = 2;
 
-  const gameMetadata: Server.GameMetadata = {
+  const metadata: Server.GameMetadata = {
     gameName: game.name,
     unlisted: !!unlisted,
     players: {},
   };
-  if (setupData !== undefined) gameMetadata.setupData = setupData;
-
-  const state = InitializeGame({ game, numPlayers, setupData });
-
+  if (setupData !== undefined) metadata.setupData = setupData;
   for (let playerIndex = 0; playerIndex < numPlayers; playerIndex++) {
-    gameMetadata.players[playerIndex] = { id: playerIndex };
+    metadata.players[playerIndex] = { id: playerIndex };
   }
 
   const gameID = lobbyConfig.uuid();
+  const initialState = InitializeGame({ game, numPlayers, setupData });
 
-  await db.setMetadata(gameID, gameMetadata);
-  await db.setState(gameID, state);
+  await db.createGame(gameID, { metadata, initialState });
 
   return gameID;
 };

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -16,13 +16,6 @@ import { InitializeGame } from '../core/initialize';
 import * as StorageAPI from './db/base';
 import { Server, Game } from '../types';
 
-const createGameMetadata = ({ gameName, unlisted }): Server.GameMetadata => ({
-  gameName,
-  unlisted,
-  players: {},
-  setupData: {},
-});
-
 /**
  * Creates a new game.
  *
@@ -38,23 +31,24 @@ export const CreateGame = async (
   db: StorageAPI.Sync | StorageAPI.Async,
   game: Game,
   numPlayers: number,
-  setupData: object,
+  setupData: any,
   lobbyConfig: Server.LobbyConfig,
   unlisted: boolean
 ) => {
-  const gameMetadata = createGameMetadata({ gameName: game.name, unlisted });
+  if (!numPlayers || typeof numPlayers !== 'number') numPlayers = 2;
 
-  const state = InitializeGame({
-    game,
-    numPlayers,
-    setupData,
-  });
+  const gameMetadata: Server.GameMetadata = {
+    gameName: game.name,
+    unlisted: !!unlisted,
+    players: {},
+  };
+  if (setupData !== undefined) gameMetadata.setupData = setupData;
+
+  const state = InitializeGame({ game, numPlayers, setupData });
 
   for (let playerIndex = 0; playerIndex < numPlayers; playerIndex++) {
     gameMetadata.players[playerIndex] = { id: playerIndex };
   }
-
-  gameMetadata.setupData = setupData;
 
   const gameID = lobbyConfig.uuid();
 
@@ -113,9 +107,6 @@ export const addApiToServer = ({
     const unlisted = ctx.request.body.unlisted;
     // The number of players for this game instance.
     let numPlayers = parseInt(ctx.request.body.numPlayers);
-    if (!numPlayers) {
-      numPlayers = 2;
-    }
 
     const game = games.find(g => g.name === gameName);
     const gameID = await CreateGame(
@@ -259,9 +250,6 @@ export const addApiToServer = ({
     const setupData = ctx.request.body.setupData;
     // The number of players for this game instance.
     let numPlayers = parseInt(ctx.request.body.numPlayers);
-    if (!numPlayers) {
-      numPlayers = 2;
-    }
 
     if (typeof playerID === 'undefined' || playerID === null) {
       ctx.throw(403, 'playerID is required');

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -64,8 +64,8 @@ export const createApiServer = ({
   lobbyConfig,
   generateCredentials,
 }: {
-  db: any;
-  games: any;
+  db: StorageAPI.Sync | StorageAPI.Async;
+  games: Game[];
   lobbyConfig?: Server.LobbyConfig;
   generateCredentials?: Server.GenerateCredentials;
 }) => {
@@ -134,7 +134,7 @@ export const addApiToServer = ({
       if (!metadata.unlisted) {
         rooms.push({
           gameID,
-          players: Object.values(metadata.players).map((player: any) => {
+          players: Object.values(metadata.players).map(player => {
             // strip away credentials
             const { credentials, ...strippedInfo } = player;
             return strippedInfo;
@@ -158,7 +158,7 @@ export const addApiToServer = ({
     }
     const strippedRoom = {
       roomID: gameID,
-      players: Object.values(metadata.players).map((player: any) => {
+      players: Object.values(metadata.players).map(player => {
         const { credentials, ...strippedInfo } = player;
         return strippedInfo;
       }),
@@ -228,7 +228,7 @@ export const addApiToServer = ({
 
     delete metadata.players[playerID].name;
     delete metadata.players[playerID].credentials;
-    if (Object.values(metadata.players).some((val: any) => val.name)) {
+    if (Object.values(metadata.players).some(player => player.name)) {
       await db.setMetadata(gameID, metadata);
     } else {
       // remove room
@@ -289,7 +289,7 @@ export const addApiToServer = ({
     };
   });
 
-  const updatePlayerMetadata = async ctx => {
+  const updatePlayerMetadata = async (ctx: Koa.Context) => {
     const gameID = ctx.params.id;
     const playerID = ctx.request.body.playerID;
     const credentials = ctx.request.body.credentials;

--- a/src/types.ts
+++ b/src/types.ts
@@ -279,7 +279,7 @@ export namespace Server {
   export interface GameMetadata {
     gameName: string;
     players: { [id: number]: PlayerMetadata };
-    setupData: any;
+    setupData?: any;
     gameover?: any;
     nextRoomID?: string;
     unlisted?: boolean;


### PR DESCRIPTION
There are quite a few changes here, but most are housekeeping/refactoring:

- **feat:** Improve/tighten game creation options checking (ca819d9)
  - Centralise setting default `numPlayers` in `CreateGame` method
  - Only add `setupData` field to game metadata if not undefined
  - Ensure `unlisted` field is always a boolean value
  - Fixes delucis/bgio-firebase#4
- **feat:** Use the `createGame` storage API when creating a game. (I guess this was missed somehow when the new API was implemented.) (40f1d7b)
- **feat:** Throw 404 error from `create` endpoint if the game name isn’t found (da8a473, a90ea78)
- **refactor:** Improved typings (af72f03, 88a75d6)
- **test:** Tidied up some of the API tests (3a00357, 09f2336, 67090d2)