### PR TITLE
Update create-react-app's installation command

### DIFF
--- a/docs/documentation/tutorial.md
+++ b/docs/documentation/tutorial.md
@@ -10,8 +10,7 @@ including [imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 the [object spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator) syntax.
 
 ```
-$ npm install -g create-react-app
-$ create-react-app game
+$ npx create-react-app game
 $ cd game
 $ npm install --save boardgame.io
 ```


### PR DESCRIPTION
create-react-app recommends using npx to create a new application:

https://create-react-app.dev/docs/getting-started#quick-start

> If you've previously installed create-react-app globally via npm install -g create-react-app, we recommend you uninstall the package using npm uninstall -g create-react-app to ensure that npx always uses the latest version.