### PR TITLE
Add pagination plugin to the docs

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -54,6 +54,7 @@
     subMaxLevel: 2,
     auto2top: true,
     search: 'auto', // default
+    pagination: {}, // default
     markdown: {
       renderer: {
         code: function(code, lang) {
@@ -72,6 +73,7 @@
 
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+<script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
 
 <script>
   ((window.gitter = {}).chat = {}).options = {

--- a/docs/documentation/sidebar.md
+++ b/docs/documentation/sidebar.md
@@ -1,6 +1,6 @@
 - Getting Started
 
-  - [Concepts](concepts.md)
+  - [Concepts](/)
   - [Tutorial](tutorial.md)
 
 - Guides


### PR DESCRIPTION
This PR adds the pagination plugin to the docs, following the conversation in #683.

While testing the docs manually, I noticed that the pagination was not showing up when accessing the documentation's `homepage` from the "Documentation" link on the homepage.

So I spent some time figuring it out and the problem comes from the fact that the documentation's `homepage` has two URLs: `/` and `/README`. This issue has been reported in [docsifyjs#1131](https://github.com/docsifyjs/docsify/issues/1131) and the recommended solution is to change the link to the homepage in the sidebar from `concepts.md` to `/`.

I updated the sidebar and it does work now. I also tested the old URL (`/README`) to make sure that it still works and it does. The pagination is not showing up on `/README` though. It's probably fine as there are no references to that URL in the documentation anymore. I think it's ok for people still accessing this URL for some reason to not have the plugin.

Here's a screenshot of the bottom of the concepts page:

![localhost_3000_documentation_](https://user-images.githubusercontent.com/2291025/81666422-50a58a80-9442-11ea-917a-82f3dcee4293.png)

Closes #683 