### PR TITLE
feat(plugins): Let moves return INVALID_MOVE after mutating G

### DIFF
--- a/src/plugins/plugin-immer.test.js
+++ b/src/plugins/plugin-immer.test.js
@@ -7,6 +7,10 @@
  */
 
 import { Client } from '../client/client';
+import { INVALID_MOVE } from '../core/reducer';
+
+// Surpress invalid move error logging
+jest.mock('../core/logger');
 
 describe('immer', () => {
   let client;
@@ -17,6 +21,10 @@ describe('immer', () => {
         moves: {
           A: G => {
             G.moveBody = true;
+          },
+          invalid: G => {
+            G.madeInvalidMove = true;
+            return INVALID_MOVE;
           },
         },
 
@@ -68,5 +76,10 @@ describe('immer', () => {
     client.moves.A();
     expect(client.getState().G.moveBody).toBe(true);
     expect(client.getState().G.onMove).toBe(true);
+  });
+
+  test('invalid move', () => {
+    client.moves.invalid();
+    expect(client.getState().G.madeInvalidMove).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #687

This changes the immer plugin to handle returning `INVALID_MOVE` after mutations have already been applied to `G`. This is different from the approach I initially considered in #687, but is actually conceptually a little simpler.

Basically, if a move returns `INVALID_MOVE` we return `undefined` to immer, which therefore accepts any state mutations, but still return `INVALID_MOVE` instead of the bad state update to the reducer.