### PR TITLE
fix: Move INVALID_MOVE constant to avoid circular dependency

### DIFF
--- a/packages/core.ts
+++ b/packages/core.ts
@@ -6,7 +6,7 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { INVALID_MOVE } from '../src/core/reducer';
+import { INVALID_MOVE } from '../src/core/constants';
 import { ActivePlayers, TurnOrder, Stage } from '../src/core/turn-order';
 import { PlayerView } from '../src/core/player-view';
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Moves can return this when they want to indicate
+ * that the combination of arguments is illegal and
+ * the move ought to be discarded.
+ */
+export const INVALID_MOVE = 'INVALID_MOVE';

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -8,7 +8,7 @@
 
 import * as plugins from '../plugins/main';
 import { Flow } from './flow';
-import { INVALID_MOVE } from './reducer';
+import { INVALID_MOVE } from './constants';
 import { ActionPayload, Game, Move, LongFormMove, State } from '../types';
 import * as logging from './logger';
 

--- a/src/core/reducer.test.js
+++ b/src/core/reducer.test.js
@@ -6,7 +6,8 @@
  * https://opensource.org/licenses/MIT.
  */
 
-import { CreateGameReducer, INVALID_MOVE } from './reducer';
+import { INVALID_MOVE } from './constants';
+import { CreateGameReducer } from './reducer';
 import { InitializeGame } from './initialize';
 import {
   makeMove,

--- a/src/core/reducer.ts
+++ b/src/core/reducer.ts
@@ -10,6 +10,7 @@ import * as Actions from './action-types';
 import * as plugins from '../plugins/main';
 import { ProcessGameConfig } from './game';
 import { error } from './logger';
+import { INVALID_MOVE } from './constants';
 import {
   ActionShape,
   Ctx,
@@ -44,13 +45,6 @@ const CanUndoMove = (G: any, ctx: Ctx, move: Move): boolean => {
 
   return move.undoable;
 };
-
-/**
- * Moves can return this when they want to indicate
- * that the combination of arguments is illegal and
- * the move ought to be discarded.
- */
-export const INVALID_MOVE = 'INVALID_MOVE';
 
 /**
  * CreateGameReducer

--- a/src/plugins/plugin-immer.test.js
+++ b/src/plugins/plugin-immer.test.js
@@ -7,7 +7,7 @@
  */
 
 import { Client } from '../client/client';
-import { INVALID_MOVE } from '../core/reducer';
+import { INVALID_MOVE } from '../core/constants';
 
 // Surpress invalid move error logging
 jest.mock('../core/logger');

--- a/src/plugins/plugin-immer.ts
+++ b/src/plugins/plugin-immer.ts
@@ -8,7 +8,7 @@
 
 import produce from 'immer';
 import { AnyFn, Ctx, Plugin } from '../types';
-import { INVALID_MOVE } from '../core/reducer';
+import { INVALID_MOVE } from '../core/constants';
 
 /**
  * Plugin that allows using Immer to make immutable changes

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { Object } from 'ts-toolbelt';
 import Koa from 'koa';
 import * as ActionCreators from './core/action-creators';
 import { Flow } from './core/flow';
-import { INVALID_MOVE } from './core/reducer';
+import { INVALID_MOVE } from './core/constants';
 import * as StorageAPI from './server/db/base';
 import { EventsAPI } from './plugins/plugin-events';
 import { RandomAPI } from './plugins/plugin-random';


### PR DESCRIPTION
This moves the `INVALID_MOVE` constant to a separate file to fix the circular dependency introduced in #688.