### PR TITLE
feat(server): Expose API router

### DIFF
--- a/docs/documentation/api/Lobby.md
+++ b/docs/documentation/api/Lobby.md
@@ -44,7 +44,6 @@ Options are:
 
 - `apiPort`: If specified, it runs the Lobby API in a separate Koa server on this port. Otherwise, it shares the same Koa server runnning on the default boardgame.io `port`.
 - `apiCallback`: Called when the Koa server is ready. Only applicable if `apiPort` is specified.
-- `uuid`: Function that returns an unique identifier, needed for creating new game ID codes. If not specified, uses [shortid](https://www.npmjs.com/package/shortid).
 
 #### Creating a room
 

--- a/docs/documentation/api/Server.md
+++ b/docs/documentation/api/Server.md
@@ -29,6 +29,8 @@ A config object with the following options:
 
 5. `authenticateCredentials` (_function_): an optional function that tests if a player’s move is made with the correct credentials when using the default socket.io transport implementation.
 
+6. `lobbyConfig` (_object_): configuration options for the Lobby API server.
+
 ### Returns
 
 An object that contains:
@@ -39,6 +41,7 @@ An object that contains:
    _({ apiServer, appServer }) => {}_
 3. app (_object_): The Koa app.
 4. db (_object_): The `db` implementation.
+5. router (_object_): The Koa Router for the server API.
 
 ### Usage
 

--- a/docs/documentation/api/Server.md
+++ b/docs/documentation/api/Server.md
@@ -24,12 +24,12 @@ A config object with the following options:
 
 3. `transport` (_object_): the transport implementation.
    If not provided, socket.io is used.
-   
-4. `generateCredentials` (_function_): an optional function that returns player credentials to store in the game metadata and validate against. If not specified, the Lobby’s `uuid` implementation will be used.
 
-5. `authenticateCredentials` (_function_): an optional function that tests if a player’s move is made with the correct credentials when using the default socket.io transport implementation.
+4. `uuid` (_function_): an optional function that returns a unique identifier, used to create new game IDs and — if `generateCredentials` is not specified — player credentials. Defaults to [shortid](https://www.npmjs.com/package/shortid).
 
-6. `lobbyConfig` (_object_): configuration options for the Lobby API server.
+5. `generateCredentials` (_function_): an optional function that returns player credentials to store in the game metadata and validate against. If not specified, the `uuid` function will be used.
+
+6. `authenticateCredentials` (_function_): an optional function that tests if a player’s move is made with the correct credentials when using the default socket.io transport implementation.
 
 ### Returns
 

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -9,7 +9,7 @@
 import request from 'supertest';
 import Koa from 'koa';
 
-import { addApiToServer, createApiServer } from './api';
+import { createRouter, configureApp } from './api';
 import { ProcessGameConfig } from '../core/game';
 import * as StorageAPI from './db/base';
 import { Game } from '../types';
@@ -62,8 +62,18 @@ class AsyncStorage extends StorageAPI.Async {
     return this.mocks.listGames(...args);
   }
 }
+describe('.createRouter', () => {
+  function addApiToServer({ app, ...args }) {
+    const router = createRouter(args as any);
+    configureApp(app, router);
+  }
 
-describe('.createApiServer', () => {
+  function createApiServer(args) {
+    const app = new Koa();
+    addApiToServer({ app, ...args });
+    return app;
+  }
+
   describe('creating a game', () => {
     let response;
     let app: Koa;
@@ -1244,9 +1254,7 @@ describe('.createApiServer', () => {
       });
     });
   });
-});
 
-describe('.addApiToServer', () => {
   describe('when server app is provided', () => {
     let db: AsyncStorage;
     let server;

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -62,13 +62,17 @@ class AsyncStorage extends StorageAPI.Async {
     return this.mocks.listGames(...args);
   }
 }
+
 describe('.createRouter', () => {
-  function addApiToServer({ app, ...args }) {
-    const router = createRouter(args as any);
+  function addApiToServer({
+    app,
+    ...args
+  }: { app: Koa } & Parameters<typeof createRouter>[0]) {
+    const router = createRouter(args);
     configureApp(app, router);
   }
 
-  function createApiServer(args) {
+  function createApiServer(args: Parameters<typeof createRouter>[0]) {
     const app = new Koa();
     addApiToServer({ app, ...args });
     return app;
@@ -100,8 +104,7 @@ describe('.createRouter', () => {
         delete process.env.API_SECRET;
 
         const uuid = () => 'gameID';
-        const lobbyConfig = { uuid };
-        app = createApiServer({ db, games, lobbyConfig });
+        app = createApiServer({ db, games, uuid });
 
         response = await request(app.callback())
           .post('/games/foo/create')
@@ -316,9 +319,7 @@ describe('.createRouter', () => {
             const app = createApiServer({
               db,
               games,
-              lobbyConfig: {
-                uuid: () => 'gameID',
-              },
+              uuid: () => 'gameID',
               generateCredentials: () => credentials,
             });
             response = await request(app.callback())
@@ -1037,10 +1038,8 @@ describe('.createRouter', () => {
     });
 
     test('creates new game data', async () => {
-      const lobbyConfig = {
-        uuid: () => 'newGameID',
-      };
-      const app = createApiServer({ db, games, lobbyConfig });
+      const uuid = () => 'newGameID';
+      const app = createApiServer({ db, games, uuid });
       response = await request(app.callback())
         .post('/games/foo/1/playAgain')
         .send('playerID=0&credentials=SECRET1&numPlayers=4');
@@ -1280,7 +1279,7 @@ describe('.createRouter', () => {
 
     test('call .use method several times with uuid', async () => {
       const uuid = () => 'foo';
-      addApiToServer({ app: server, db, games, lobbyConfig: { uuid } });
+      addApiToServer({ app: server, db, games, uuid });
       expect(server.use.mock.calls.length).toBeGreaterThan(1);
     });
   });

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -55,34 +55,17 @@ export const CreateGame = async (
   return gameID;
 };
 
-export const createApiServer = ({
+export const createRouter = ({
   db,
   games,
   lobbyConfig,
   generateCredentials,
 }: {
-  db: StorageAPI.Sync | StorageAPI.Async;
-  games: Game[];
-  lobbyConfig?: Server.LobbyConfig;
-  generateCredentials?: Server.GenerateCredentials;
-}) => {
-  const app = new Koa();
-  return addApiToServer({ app, db, games, lobbyConfig, generateCredentials });
-};
-
-export const addApiToServer = ({
-  app,
-  db,
-  games,
-  lobbyConfig,
-  generateCredentials,
-}: {
-  app: Koa;
   games: Game[];
   lobbyConfig?: Server.LobbyConfig;
   generateCredentials?: Server.GenerateCredentials;
   db: StorageAPI.Sync | StorageAPI.Async;
-}) => {
+}): Router => {
   if (!lobbyConfig) lobbyConfig = {};
   lobbyConfig = {
     ...lobbyConfig,
@@ -335,6 +318,10 @@ export const addApiToServer = ({
 
   router.post('/games/:name/:id/update', koaBody(), updatePlayerMetadata);
 
+  return router;
+};
+
+export const configureApp = (app: Koa, router: Router): void => {
   app.use(cors());
 
   // If API_SECRET is set, then require that requests set an
@@ -351,6 +338,4 @@ export const addApiToServer = ({
   });
 
   app.use(router.routes()).use(router.allowedMethods());
-
-  return app;
 };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -62,10 +62,10 @@ interface ServerOpts {
   games: Game[];
   db?: StorageAPI.Async | StorageAPI.Sync;
   transport?;
+  uuid?: () => string;
   authenticateCredentials?: ServerTypes.AuthenticateCredentials;
   generateCredentials?: ServerTypes.GenerateCredentials;
   https?: HttpsOptions;
-  lobbyConfig?: ServerTypes.LobbyConfig;
 }
 
 /**
@@ -86,7 +86,7 @@ export function Server({
   authenticateCredentials,
   generateCredentials,
   https,
-  lobbyConfig,
+  uuid,
 }: ServerOpts) {
   const app = new Koa();
 
@@ -109,7 +109,7 @@ export function Server({
   }
   transport.init(app, games);
 
-  const router = createRouter({ db, games, lobbyConfig, generateCredentials });
+  const router = createRouter({ db, games, uuid, generateCredentials });
 
   return {
     app,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,7 +7,6 @@
  */
 
 import Koa from 'koa';
-import Router from 'koa-router';
 
 import { createRouter, configureApp } from './api';
 import { DBFromEnv } from './db';
@@ -18,12 +17,13 @@ import { Server as ServerTypes, Game, StorageAPI } from '../types';
 
 export type KoaServer = ReturnType<Koa['listen']>;
 
-type LobbyConfig = ServerTypes.LobbyConfig & ServerTypes.LobbyRuntimeSettings;
-
 interface ServerConfig {
   port?: number;
   callback?: () => void;
-  lobbyConfig?: LobbyConfig;
+  lobbyConfig?: {
+    apiPort: number;
+    apiCallback?: () => void;
+  };
 }
 
 interface HttpsOptions {
@@ -58,127 +58,14 @@ const getPortFromServer = (server: KoaServer): string | number | null => {
   return address.port;
 };
 
-type DB = StorageAPI.Async | StorageAPI.Sync;
-type Servers = { apiServer?: KoaServer; appServer: KoaServer };
-
 interface ServerOpts {
   games: Game[];
-  db?: DB;
+  db?: StorageAPI.Async | StorageAPI.Sync;
   transport?;
   authenticateCredentials?: ServerTypes.AuthenticateCredentials;
   generateCredentials?: ServerTypes.GenerateCredentials;
   https?: HttpsOptions;
   lobbyConfig?: ServerTypes.LobbyConfig;
-}
-
-class ServerInstance {
-  private _app: Koa;
-  private _db: DB;
-  private _router: Router;
-  private _games: Game[];
-  private _generateCredentials: ServerTypes.GenerateCredentials;
-
-  constructor({
-    games,
-    db,
-    transport,
-    authenticateCredentials,
-    generateCredentials,
-    https,
-    lobbyConfig,
-  }: ServerOpts) {
-    const app = new Koa();
-
-    games = games.map(ProcessGameConfig);
-
-    if (db === undefined) {
-      db = DBFromEnv();
-    }
-    app.context.db = db;
-
-    if (transport === undefined) {
-      const auth =
-        typeof authenticateCredentials === 'function'
-          ? authenticateCredentials
-          : true;
-      transport = new SocketIO({
-        auth,
-        https,
-      });
-    }
-    transport.init(app, games);
-
-    this._games = games;
-    this._generateCredentials = generateCredentials;
-    this._app = app;
-    this._db = db;
-    this.setRouter(lobbyConfig);
-  }
-
-  private setRouter(lobbyConfig: ServerTypes.LobbyConfig): void {
-    this._router = createRouter({
-      db: this._db,
-      games: this._games,
-      lobbyConfig,
-      generateCredentials: this._generateCredentials,
-    });
-  }
-
-  get app(): Koa {
-    return this._app;
-  }
-
-  get db(): DB {
-    return this._db;
-  }
-
-  get router(): Router {
-    return this._router;
-  }
-
-  async run(
-    portOrConfig: number | ServerConfig,
-    callback?: () => void
-  ): Promise<Servers> {
-    const serverRunConfig = createServerRunConfig(portOrConfig, callback);
-
-    // DB
-    await this.db.connect();
-
-    // Lobby API
-    const lobbyConfig = serverRunConfig.lobbyConfig;
-    if (lobbyConfig) this.setRouter(lobbyConfig);
-    let apiServer: KoaServer | undefined;
-    if (!lobbyConfig || !lobbyConfig.apiPort) {
-      configureApp(this.app, this.router);
-    } else {
-      // Run API in a separate Koa app.
-      const api = new Koa();
-      configureApp(api, this.router);
-      await new Promise(resolve => {
-        apiServer = api.listen(lobbyConfig.apiPort, resolve);
-      });
-      if (lobbyConfig.apiCallback) lobbyConfig.apiCallback();
-      logger.info(`API serving on ${getPortFromServer(apiServer)}...`);
-    }
-
-    // Run Game Server (+ API, if necessary).
-    let appServer: KoaServer;
-    await new Promise(resolve => {
-      appServer = this.app.listen(serverRunConfig.port, resolve);
-    });
-    if (serverRunConfig.callback) serverRunConfig.callback();
-    logger.info(`App serving on ${getPortFromServer(appServer)}...`);
-
-    return { apiServer, appServer };
-  }
-
-  kill(servers: Servers): void {
-    if (servers.apiServer) {
-      servers.apiServer.close();
-    }
-    servers.appServer.close();
-  }
 }
 
 /**
@@ -192,6 +79,81 @@ class ServerInstance {
  * @param https - HTTPS configuration options passed through to the TLS module.
  * @param lobbyConfig - Configuration options for the Lobby API server.
  */
-export function Server(opts: ServerOpts): ServerInstance {
-  return new ServerInstance(opts);
+export function Server({
+  games,
+  db,
+  transport,
+  authenticateCredentials,
+  generateCredentials,
+  https,
+  lobbyConfig,
+}: ServerOpts) {
+  const app = new Koa();
+
+  games = games.map(ProcessGameConfig);
+
+  if (db === undefined) {
+    db = DBFromEnv();
+  }
+  app.context.db = db;
+
+  if (transport === undefined) {
+    const auth =
+      typeof authenticateCredentials === 'function'
+        ? authenticateCredentials
+        : true;
+    transport = new SocketIO({
+      auth,
+      https,
+    });
+  }
+  transport.init(app, games);
+
+  const router = createRouter({ db, games, lobbyConfig, generateCredentials });
+
+  return {
+    app,
+    db,
+    router,
+
+    run: async (portOrConfig: number | ServerConfig, callback?: () => void) => {
+      const serverRunConfig = createServerRunConfig(portOrConfig, callback);
+
+      // DB
+      await db.connect();
+
+      // Lobby API
+      const lobbyConfig = serverRunConfig.lobbyConfig;
+      let apiServer: KoaServer | undefined;
+      if (!lobbyConfig || !lobbyConfig.apiPort) {
+        configureApp(app, router);
+      } else {
+        // Run API in a separate Koa app.
+        const api = new Koa();
+        configureApp(api, router);
+        await new Promise(resolve => {
+          apiServer = api.listen(lobbyConfig.apiPort, resolve);
+        });
+        if (lobbyConfig.apiCallback) lobbyConfig.apiCallback();
+        logger.info(`API serving on ${getPortFromServer(apiServer)}...`);
+      }
+
+      // Run Game Server (+ API, if necessary).
+      let appServer: KoaServer;
+      await new Promise(resolve => {
+        appServer = app.listen(serverRunConfig.port, resolve);
+      });
+      if (serverRunConfig.callback) serverRunConfig.callback();
+      logger.info(`App serving on ${getPortFromServer(appServer)}...`);
+
+      return { apiServer, appServer };
+    },
+
+    kill: (servers: { apiServer?: KoaServer; appServer: KoaServer }) => {
+      if (servers.apiServer) {
+        servers.apiServer.close();
+      }
+      servers.appServer.close();
+    },
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -288,8 +288,6 @@ export namespace Server {
   export interface LobbyConfig {
     uuid?: () => string;
     generateCredentials?: GenerateCredentials;
-    apiPort?: number;
-    apiCallback?: () => void;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -289,11 +289,6 @@ export namespace Server {
     uuid?: () => string;
     generateCredentials?: GenerateCredentials;
   }
-
-  export interface LobbyRuntimeSettings {
-    apiPort?: number;
-    apiCallback?: () => void;
-  }
 }
 
 export namespace CredentialedActionShape {

--- a/src/types.ts
+++ b/src/types.ts
@@ -289,6 +289,11 @@ export namespace Server {
     uuid?: () => string;
     generateCredentials?: GenerateCredentials;
   }
+
+  export interface LobbyRuntimeSettings {
+    apiPort?: number;
+    apiCallback?: () => void;
+  }
 }
 
 export namespace CredentialedActionShape {

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,11 +284,6 @@ export namespace Server {
     nextRoomID?: string;
     unlisted?: boolean;
   }
-
-  export interface LobbyConfig {
-    uuid?: () => string;
-    generateCredentials?: GenerateCredentials;
-  }
 }
 
 export namespace CredentialedActionShape {


### PR DESCRIPTION
This pull request refactors `Server.run` to separate setting up the API routes from running the API server. Splitting these responsibilities enables developers to more easily customize hosting of the app, e.g. customizing the CORS setup, mounting the API routes at a path prefix, etc.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
