### PR TITLE
Fix #703 - Use the term "match" in the API and Lobby

### DIFF
--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -114,7 +114,7 @@ The `Board` component will receive the following as `props`:
 11. `playerID`: The player ID associated with the client.
 
 12. `matchMetadata`: An object containing the players that have joined
-    the game from a [room](/api/Lobby.md).
+    the game from a [match](/api/Lobby.md).
 
     Example:
 

--- a/docs/documentation/api/Client.md
+++ b/docs/documentation/api/Client.md
@@ -113,7 +113,7 @@ The `Board` component will receive the following as `props`:
 
 11. `playerID`: The player ID associated with the client.
 
-12. `gameMetadata`: An object containing the players that have joined
+12. `matchMetadata`: An object containing the players that have joined
     the game from a [room](/api/Lobby.md).
 
     Example:

--- a/docs/documentation/api/Lobby.md
+++ b/docs/documentation/api/Lobby.md
@@ -25,11 +25,11 @@ The [Server](/api/Server) hosts the Lobby REST API that can be used to create an
 authenticate clients to prove that they have the right to send
 actions on behalf of a player.
 
-Authenticated games are created with server-side tokens for each player. You can create a room with the `create` API call, and join a player to a room with the `join` API call.
+Authenticated games are created with server-side tokens for each player. You can create a match with the `create` API call, and join a player to a match with the `join` API call.
 
 A game that is authenticated will not accept moves from a client on behalf of a player without the appropriate credential token.
 
-Use the `create` API call to create a room that requires credential tokens. When you call the `join` API, you can retrieve the credential token for a particular player.
+Use the `create` API call to create a match that requires credential tokens. When you call the `join` API, you can retrieve the credential token for a particular player.
 
 #### Configuration
 
@@ -45,11 +45,11 @@ Options are:
 - `apiPort`: If specified, it runs the Lobby API in a separate Koa server on this port. Otherwise, it shares the same Koa server runnning on the default boardgame.io `port`.
 - `apiCallback`: Called when the Koa server is ready. Only applicable if `apiPort` is specified.
 
-#### Creating a room
+#### Creating a match
 
 ##### POST `/games/{name}/create`
 
-Creates a new authenticated room for a game named `name`.
+Creates a new authenticated match for a game named `name`.
 
 Accepts three parameters:
 
@@ -57,7 +57,7 @@ Accepts three parameters:
 
 `setupData` (optional): custom object that is passed to the game `setup` function.
 
-`unlisted` (optional): if set to `true`, the room will be excluded from the public list of room instances.
+`unlisted` (optional): if set to `true`, the match will be excluded from the public list of match instances.
 
 Returns `matchID`, which is the ID of the newly created game instance.
 
@@ -65,7 +65,7 @@ Returns `matchID`, which is the ID of the newly created game instance.
 
 ##### POST `/games/{name}/{id}/join`
 
-Allows a player to join a particular room instance `id` of a game named `name`.
+Allows a player to join a particular match instance `id` of a game named `name`.
 
 Accepts three JSON body parameters:
 
@@ -81,7 +81,7 @@ Returns `playerCredentials` which is the token this player will require to authe
 
 ##### POST `/games/{name}/{id}/update`
 
-Rename and/or update additional information of a user in the room instance `id` of a game named `name` previously joined by the player.
+Rename and/or update additional information of a user in the match instance `id` of a game named `name` previously joined by the player.
 
 Accepts four parameters, requires at least one of the two optional parameters:
 
@@ -93,11 +93,11 @@ Accepts four parameters, requires at least one of the two optional parameters:
 
 `data` (optional): additional information associated to the player.
 
-#### Leaving a room
+#### Leaving a match
 
 ##### POST `/games/{name}/{id}/leave`
 
-Leave the room instance `id` of a game named `name` previously joined by the player.
+Leave the match instance `id` of a game named `name` previously joined by the player.
 
 Accepts two parameters, all required:
 
@@ -105,29 +105,29 @@ Accepts two parameters, all required:
 
 `credentials`: the authentication token of the player.
 
-#### Listing all room instances of a given game
+#### Listing all match instances of a given game
 
 ##### GET `/games/{name}`
 
-Returns all room instances of the game named `name`.
+Returns all match instances of the game named `name`.
 
 Returns an array of `matches`. Each instance has fields:
 
-`matchID`: the ID of the room instance.
+`matchID`: the ID of the match instance.
 
 `players`: the list of seats and players that have joined the game, if any.
 
 `setupData` (optional): custom object that was passed to the game `setup` function.
 
-#### Getting specific instance of a room by its ID
+#### Getting specific instance of a match by its ID
 
 ##### GET `/games/{name}/{id}`
 
-Returns a room instance given its matchID.
+Returns a match instance given its matchID.
 
-Returns a room instance. Each instance has fields:
+Returns a match instance. Each instance has fields:
 
-`matchID`: the ID of the room instance.
+`matchID`: the ID of the match instance.
 
 `players`: the list of seats and players that have joined the game, if any.
 
@@ -143,9 +143,9 @@ All actions for an authenticated game require an additional payload field `crede
 
 `{name}` (required): the name of the game being played again.
 
-`{id}` (required): the ID of the previous finished room.
+`{id}` (required): the ID of the previous finished match.
 
-Given a previous room, generates a room ID where users should go if they want to play again. Creates this new room if it didn't exist before.
+Given a previous match, generates a match ID where users should go if they want to play again. Creates this new match if it didn't exist before.
 
 Accepts these parameters:
 
@@ -153,4 +153,4 @@ Accepts these parameters:
 
 `credentials` (required): player's credentials.
 
-Returns `nextRoomID`, which is the ID of the newly created room that the user should go to play again.
+Returns `nextMatchID`, which is the ID of the newly created match that the user should go to play again.

--- a/docs/documentation/api/Lobby.md
+++ b/docs/documentation/api/Lobby.md
@@ -59,7 +59,7 @@ Accepts three parameters:
 
 `unlisted` (optional): if set to `true`, the room will be excluded from the public list of room instances.
 
-Returns `roomID`, which is the ID of the newly created game instance.
+Returns `matchID`, which is the ID of the newly created game instance.
 
 #### Joining a game
 
@@ -113,7 +113,7 @@ Returns all room instances of the game named `name`.
 
 Returns an array of `matches`. Each instance has fields:
 
-`roomID`: the ID of the room instance.
+`matchID`: the ID of the room instance.
 
 `players`: the list of seats and players that have joined the game, if any.
 
@@ -123,11 +123,11 @@ Returns an array of `matches`. Each instance has fields:
 
 ##### GET `/games/{name}/{id}`
 
-Returns a room instance given its roomID.
+Returns a room instance given its matchID.
 
 Returns a room instance. Each instance has fields:
 
-`roomID`: the ID of the room instance.
+`matchID`: the ID of the room instance.
 
 `players`: the list of seats and players that have joined the game, if any.
 

--- a/docs/documentation/api/Lobby.md
+++ b/docs/documentation/api/Lobby.md
@@ -21,7 +21,7 @@ import { Lobby } from 'boardgame.io/react';
 
 ### Server-side API
 
-The [Server](/api/Server) hosts the Lobby REST API that can be used to create and join rooms. It is particularly useful when you want to
+The [Server](/api/Server) hosts the Lobby REST API that can be used to create and join matches. It is particularly useful when you want to
 authenticate clients to prove that they have the right to send
 actions on behalf of a player.
 
@@ -111,7 +111,7 @@ Accepts two parameters, all required:
 
 Returns all room instances of the game named `name`.
 
-Returns an array of `rooms`. Each instance has fields:
+Returns an array of `matches`. Each instance has fields:
 
 `roomID`: the ID of the room instance.
 

--- a/src/lobby/connection.js
+++ b/src/lobby/connection.js
@@ -37,7 +37,7 @@ class _LobbyConnectionImpl {
         this.matches = this.matches.concat(gameJson.matches);
       }
     } catch (error) {
-      throw new Error('failed to retrieve list of games (' + error + ')');
+      throw new Error('failed to retrieve list of matches (' + error + ')');
     }
   }
 
@@ -92,7 +92,7 @@ class _LobbyConnectionImpl {
   async leave(gameName, matchID) {
     try {
       let inst = this._getMatchInstance(matchID);
-      if (!inst) throw new Error('game instance not found');
+      if (!inst) throw new Error('match instance not found');
       for (let player of inst.players) {
         if (player.name === this.playerName) {
           const resp = await fetch(

--- a/src/lobby/connection.js
+++ b/src/lobby/connection.js
@@ -12,7 +12,7 @@ class _LobbyConnectionImpl {
     this.playerName = playerName || 'Visitor';
     this.playerCredentials = playerCredentials;
     this.server = server;
-    this.rooms = [];
+    this.matches = [];
   }
 
   _baseUrl() {
@@ -21,7 +21,7 @@ class _LobbyConnectionImpl {
 
   async refresh() {
     try {
-      this.rooms.length = 0;
+      this.matches.length = 0;
       const resp = await fetch(this._baseUrl());
       if (resp.status !== 200) {
         throw new Error('HTTP status ' + resp.status);
@@ -31,10 +31,10 @@ class _LobbyConnectionImpl {
         if (!this._getGameComponents(gameName)) continue;
         const gameResp = await fetch(this._baseUrl() + '/' + gameName);
         const gameJson = await gameResp.json();
-        for (let inst of gameJson.rooms) {
+        for (let inst of gameJson.matches) {
           inst.gameName = gameName;
         }
-        this.rooms = this.rooms.concat(gameJson.rooms);
+        this.matches = this.matches.concat(gameJson.matches);
       }
     } catch (error) {
       throw new Error('failed to retrieve list of games (' + error + ')');
@@ -42,7 +42,7 @@ class _LobbyConnectionImpl {
   }
 
   _getGameInstance(gameID) {
-    for (let inst of this.rooms) {
+    for (let inst of this.matches) {
       if (inst['gameID'] === gameID) return inst;
     }
   }
@@ -54,7 +54,7 @@ class _LobbyConnectionImpl {
   }
 
   _findPlayer(playerName) {
-    for (let inst of this.rooms) {
+    for (let inst of this.matches) {
       if (inst.players.some(player => player.name === playerName)) return inst;
     }
   }
@@ -125,7 +125,7 @@ class _LobbyConnectionImpl {
     if (inst) {
       await this.leave(inst.gameName, inst.gameID);
     }
-    this.rooms = [];
+    this.matches = [];
     this.playerName = 'Visitor';
   }
 

--- a/src/lobby/connection.js
+++ b/src/lobby/connection.js
@@ -41,7 +41,7 @@ class _LobbyConnectionImpl {
     }
   }
 
-  _getGameInstance(matchID) {
+  _getMatchInstance(matchID) {
     for (let inst of this.matches) {
       if (inst['matchID'] === matchID) return inst;
     }
@@ -65,7 +65,7 @@ class _LobbyConnectionImpl {
       if (inst) {
         throw new Error('player has already joined ' + inst.matchID);
       }
-      inst = this._getGameInstance(matchID);
+      inst = this._getMatchInstance(matchID);
       if (!inst) {
         throw new Error('game instance ' + matchID + ' not found');
       }
@@ -85,13 +85,13 @@ class _LobbyConnectionImpl {
       inst.players[Number.parseInt(playerID)].name = this.playerName;
       this.playerCredentials = json.playerCredentials;
     } catch (error) {
-      throw new Error('failed to join room ' + matchID + ' (' + error + ')');
+      throw new Error('failed to join match ' + matchID + ' (' + error + ')');
     }
   }
 
   async leave(gameName, matchID) {
     try {
-      let inst = this._getGameInstance(matchID);
+      let inst = this._getMatchInstance(matchID);
       if (!inst) throw new Error('game instance not found');
       for (let player of inst.players) {
         if (player.name === this.playerName) {
@@ -114,9 +114,9 @@ class _LobbyConnectionImpl {
           return;
         }
       }
-      throw new Error('player not found in room');
+      throw new Error('player not found in match');
     } catch (error) {
-      throw new Error('failed to leave room ' + matchID + ' (' + error + ')');
+      throw new Error('failed to leave match ' + matchID + ' (' + error + ')');
     }
   }
 
@@ -148,7 +148,7 @@ class _LobbyConnectionImpl {
       if (resp.status !== 200) throw new Error('HTTP status ' + resp.status);
     } catch (error) {
       throw new Error(
-        'failed to create room for ' + gameName + ' (' + error + ')'
+        'failed to create match for ' + gameName + ' (' + error + ')'
       );
     }
   }

--- a/src/lobby/connection.js
+++ b/src/lobby/connection.js
@@ -41,9 +41,9 @@ class _LobbyConnectionImpl {
     }
   }
 
-  _getGameInstance(gameID) {
+  _getGameInstance(matchID) {
     for (let inst of this.matches) {
-      if (inst['gameID'] === gameID) return inst;
+      if (inst['matchID'] === matchID) return inst;
     }
   }
 
@@ -59,18 +59,18 @@ class _LobbyConnectionImpl {
     }
   }
 
-  async join(gameName, gameID, playerID) {
+  async join(gameName, matchID, playerID) {
     try {
       let inst = this._findPlayer(this.playerName);
       if (inst) {
-        throw new Error('player has already joined ' + inst.gameID);
+        throw new Error('player has already joined ' + inst.matchID);
       }
-      inst = this._getGameInstance(gameID);
+      inst = this._getGameInstance(matchID);
       if (!inst) {
-        throw new Error('game instance ' + gameID + ' not found');
+        throw new Error('game instance ' + matchID + ' not found');
       }
       const resp = await fetch(
-        this._baseUrl() + '/' + gameName + '/' + gameID + '/join',
+        this._baseUrl() + '/' + gameName + '/' + matchID + '/join',
         {
           method: 'POST',
           body: JSON.stringify({
@@ -85,18 +85,18 @@ class _LobbyConnectionImpl {
       inst.players[Number.parseInt(playerID)].name = this.playerName;
       this.playerCredentials = json.playerCredentials;
     } catch (error) {
-      throw new Error('failed to join room ' + gameID + ' (' + error + ')');
+      throw new Error('failed to join room ' + matchID + ' (' + error + ')');
     }
   }
 
-  async leave(gameName, gameID) {
+  async leave(gameName, matchID) {
     try {
-      let inst = this._getGameInstance(gameID);
+      let inst = this._getGameInstance(matchID);
       if (!inst) throw new Error('game instance not found');
       for (let player of inst.players) {
         if (player.name === this.playerName) {
           const resp = await fetch(
-            this._baseUrl() + '/' + gameName + '/' + gameID + '/leave',
+            this._baseUrl() + '/' + gameName + '/' + matchID + '/leave',
             {
               method: 'POST',
               body: JSON.stringify({
@@ -116,14 +116,14 @@ class _LobbyConnectionImpl {
       }
       throw new Error('player not found in room');
     } catch (error) {
-      throw new Error('failed to leave room ' + gameID + ' (' + error + ')');
+      throw new Error('failed to leave room ' + matchID + ' (' + error + ')');
     }
   }
 
   async disconnect() {
     let inst = this._findPlayer(this.playerName);
     if (inst) {
-      await this.leave(inst.gameName, inst.gameID);
+      await this.leave(inst.gameName, inst.matchID);
     }
     this.matches = [];
     this.playerName = 'Visitor';

--- a/src/lobby/connection.test.js
+++ b/src/lobby/connection.test.js
@@ -10,21 +10,21 @@ import { LobbyConnection } from './connection.js';
 
 describe('lobby', () => {
   let lobby;
-  let room1, room2;
+  let match1, match2;
   let jsonResult = [];
   let nextStatus = 200;
 
   beforeEach(async () => {
-    room1 = { matchID: 'matchID_1', players: [{ id: '0' }] };
-    room2 = { matchID: 'matchID_2', players: [{ id: '1' }] };
+    match1 = { matchID: 'matchID_1', players: [{ id: '0' }] };
+    match2 = { matchID: 'matchID_2', players: [{ id: '1' }] };
     // result of connection requests
     jsonResult = [
       () => ['game1', 'game2'],
       () => {
-        return { matches: [room1] };
+        return { matches: [match1] };
       },
       () => {
-        return { matches: [room2] };
+        return { matches: [match2] };
       },
     ];
     let nextResult = jsonResult.shift.bind(jsonResult);
@@ -60,7 +60,7 @@ describe('lobby', () => {
     describe('get list of matches', () => {
       test('when the server requests succeed', async () => {
         expect(fetch).toHaveBeenCalledTimes(3);
-        expect(lobby.matches).toEqual([room1, room2]);
+        expect(lobby.matches).toEqual([match1, match2]);
       });
       test('when the server request fails', async () => {
         nextStatus = 404;
@@ -73,14 +73,14 @@ describe('lobby', () => {
       });
     });
 
-    describe('join a room', () => {
+    describe('join a match', () => {
       beforeEach(async () => {
         // result of request 'join'
         jsonResult.push(() => {
           return { playerCredentials: 'SECRET' };
         });
       });
-      test('when the room exists', async () => {
+      test('when the match exists', async () => {
         await lobby.join('game1', 'matchID_1', '0');
         expect(fetch).toHaveBeenCalledTimes(4);
         expect(lobby.matches[0].players[0]).toEqual({
@@ -89,16 +89,16 @@ describe('lobby', () => {
         });
         expect(lobby.playerCredentials).toEqual('SECRET');
       });
-      test('when the room does not exist', async () => {
+      test('when the match does not exist', async () => {
         try {
           await lobby.join('game1', 'matchID_3', '0');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
-        expect(lobby.matches).toEqual([room1, room2]);
+        expect(lobby.matches).toEqual([match1, match2]);
       });
       test('when the seat is not available', async () => {
-        room1.players[0].name = 'Bob';
+        match1.players[0].name = 'Bob';
         try {
           await lobby.join('game1', 'matchID_3', '0');
         } catch (error) {
@@ -114,7 +114,7 @@ describe('lobby', () => {
         }
       });
       test('when the player has already joined another game', async () => {
-        room2.players[0].name = 'Bob';
+        match2.players[0].name = 'Bob';
         try {
           await lobby.join('game1', 'matchID_1', '0');
         } catch (error) {
@@ -123,7 +123,7 @@ describe('lobby', () => {
       });
     });
 
-    describe('leave a room', () => {
+    describe('leave a match', () => {
       beforeEach(async () => {
         // result of request 'join'
         jsonResult.push(() => {
@@ -135,21 +135,21 @@ describe('lobby', () => {
           return {};
         });
       });
-      test('when the room exists', async () => {
+      test('when the match exists', async () => {
         await lobby.leave('game1', 'matchID_1');
         expect(fetch).toHaveBeenCalledTimes(5);
-        expect(lobby.matches).toEqual([room1, room2]);
+        expect(lobby.matches).toEqual([match1, match2]);
       });
-      test('when the room does not exist', async () => {
+      test('when the match does not exist', async () => {
         try {
           await lobby.leave('game1', 'matchID_3');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
         expect(fetch).toHaveBeenCalledTimes(4);
-        expect(lobby.matches).toEqual([room1, room2]);
+        expect(lobby.matches).toEqual([match1, match2]);
       });
-      test('when the player is not in the room', async () => {
+      test('when the player is not in the match', async () => {
         await lobby.leave('game1', 'matchID_1');
         expect(fetch).toHaveBeenCalledTimes(5);
         try {
@@ -174,7 +174,7 @@ describe('lobby', () => {
         await lobby.disconnect();
         expect(lobby.matches).toEqual([]);
       });
-      test('when the player had joined a room', async () => {
+      test('when the player had joined a match', async () => {
         // result of request 'join'
         jsonResult.push(() => {
           return { playerCredentials: 'SECRET' };
@@ -189,7 +189,7 @@ describe('lobby', () => {
       });
     });
 
-    describe('create a room', () => {
+    describe('create a match', () => {
       test('when the server request succeeds', async () => {
         await lobby.create('game1', 2);
         expect(fetch).toHaveBeenCalledTimes(4);
@@ -232,7 +232,7 @@ describe('lobby', () => {
     });
     test('get list of matches for supported games', async () => {
       expect(fetch).toHaveBeenCalledTimes(2);
-      expect(lobby.matches).toEqual([room1]);
+      expect(lobby.matches).toEqual([match1]);
     });
   });
 });

--- a/src/lobby/connection.test.js
+++ b/src/lobby/connection.test.js
@@ -113,7 +113,7 @@ describe('lobby', () => {
           expect(error).toBeInstanceOf(Error);
         }
       });
-      test('when the player has already joined another game', async () => {
+      test('when the player has already joined another match', async () => {
         match2.players[0].name = 'Bob';
         try {
           await lobby.join('game1', 'matchID_1', '0');

--- a/src/lobby/connection.test.js
+++ b/src/lobby/connection.test.js
@@ -21,10 +21,10 @@ describe('lobby', () => {
     jsonResult = [
       () => ['game1', 'game2'],
       () => {
-        return { rooms: [room1] };
+        return { matches: [room1] };
       },
       () => {
-        return { rooms: [room2] };
+        return { matches: [room2] };
       },
     ];
     let nextResult = jsonResult.shift.bind(jsonResult);
@@ -57,10 +57,10 @@ describe('lobby', () => {
       await lobby.refresh();
     });
 
-    describe('get list of rooms', () => {
+    describe('get list of matches', () => {
       test('when the server requests succeed', async () => {
         expect(fetch).toHaveBeenCalledTimes(3);
-        expect(lobby.rooms).toEqual([room1, room2]);
+        expect(lobby.matches).toEqual([room1, room2]);
       });
       test('when the server request fails', async () => {
         nextStatus = 404;
@@ -69,7 +69,7 @@ describe('lobby', () => {
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
-        expect(lobby.rooms).toEqual([]);
+        expect(lobby.matches).toEqual([]);
       });
     });
 
@@ -83,7 +83,7 @@ describe('lobby', () => {
       test('when the room exists', async () => {
         await lobby.join('game1', 'gameID_1', '0');
         expect(fetch).toHaveBeenCalledTimes(4);
-        expect(lobby.rooms[0].players[0]).toEqual({
+        expect(lobby.matches[0].players[0]).toEqual({
           id: '0',
           name: 'Bob',
         });
@@ -95,7 +95,7 @@ describe('lobby', () => {
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
-        expect(lobby.rooms).toEqual([room1, room2]);
+        expect(lobby.matches).toEqual([room1, room2]);
       });
       test('when the seat is not available', async () => {
         room1.players[0].name = 'Bob';
@@ -138,7 +138,7 @@ describe('lobby', () => {
       test('when the room exists', async () => {
         await lobby.leave('game1', 'gameID_1');
         expect(fetch).toHaveBeenCalledTimes(5);
-        expect(lobby.rooms).toEqual([room1, room2]);
+        expect(lobby.matches).toEqual([room1, room2]);
       });
       test('when the room does not exist', async () => {
         try {
@@ -147,7 +147,7 @@ describe('lobby', () => {
           expect(error).toBeInstanceOf(Error);
         }
         expect(fetch).toHaveBeenCalledTimes(4);
-        expect(lobby.rooms).toEqual([room1, room2]);
+        expect(lobby.matches).toEqual([room1, room2]);
       });
       test('when the player is not in the room', async () => {
         await lobby.leave('game1', 'gameID_1');
@@ -172,7 +172,7 @@ describe('lobby', () => {
       beforeEach(async () => {});
       test('when the player leaves the lobby', async () => {
         await lobby.disconnect();
-        expect(lobby.rooms).toEqual([]);
+        expect(lobby.matches).toEqual([]);
       });
       test('when the player had joined a room', async () => {
         // result of request 'join'
@@ -185,7 +185,7 @@ describe('lobby', () => {
           return {};
         });
         await lobby.disconnect();
-        expect(lobby.rooms).toEqual([]);
+        expect(lobby.matches).toEqual([]);
       });
     });
 
@@ -230,9 +230,9 @@ describe('lobby', () => {
       });
       await lobby.refresh();
     });
-    test('get list of rooms for supported games', async () => {
+    test('get list of matches for supported games', async () => {
       expect(fetch).toHaveBeenCalledTimes(2);
-      expect(lobby.rooms).toEqual([room1]);
+      expect(lobby.matches).toEqual([room1]);
     });
   });
 });

--- a/src/lobby/connection.test.js
+++ b/src/lobby/connection.test.js
@@ -15,8 +15,8 @@ describe('lobby', () => {
   let nextStatus = 200;
 
   beforeEach(async () => {
-    room1 = { gameID: 'gameID_1', players: [{ id: '0' }] };
-    room2 = { gameID: 'gameID_2', players: [{ id: '1' }] };
+    room1 = { matchID: 'matchID_1', players: [{ id: '0' }] };
+    room2 = { matchID: 'matchID_2', players: [{ id: '1' }] };
     // result of connection requests
     jsonResult = [
       () => ['game1', 'game2'],
@@ -81,7 +81,7 @@ describe('lobby', () => {
         });
       });
       test('when the room exists', async () => {
-        await lobby.join('game1', 'gameID_1', '0');
+        await lobby.join('game1', 'matchID_1', '0');
         expect(fetch).toHaveBeenCalledTimes(4);
         expect(lobby.matches[0].players[0]).toEqual({
           id: '0',
@@ -91,7 +91,7 @@ describe('lobby', () => {
       });
       test('when the room does not exist', async () => {
         try {
-          await lobby.join('game1', 'gameID_3', '0');
+          await lobby.join('game1', 'matchID_3', '0');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
@@ -100,7 +100,7 @@ describe('lobby', () => {
       test('when the seat is not available', async () => {
         room1.players[0].name = 'Bob';
         try {
-          await lobby.join('game1', 'gameID_3', '0');
+          await lobby.join('game1', 'matchID_3', '0');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
@@ -108,7 +108,7 @@ describe('lobby', () => {
       test('when the server request fails', async () => {
         nextStatus = 404;
         try {
-          await lobby.join('game1', 'gameID_1', '0');
+          await lobby.join('game1', 'matchID_1', '0');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
@@ -116,7 +116,7 @@ describe('lobby', () => {
       test('when the player has already joined another game', async () => {
         room2.players[0].name = 'Bob';
         try {
-          await lobby.join('game1', 'gameID_1', '0');
+          await lobby.join('game1', 'matchID_1', '0');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
@@ -129,20 +129,20 @@ describe('lobby', () => {
         jsonResult.push(() => {
           return { playerCredentials: 'SECRET' };
         });
-        await lobby.join('game1', 'gameID_1', '0');
+        await lobby.join('game1', 'matchID_1', '0');
         // result of request 'leave'
         jsonResult.push(() => {
           return {};
         });
       });
       test('when the room exists', async () => {
-        await lobby.leave('game1', 'gameID_1');
+        await lobby.leave('game1', 'matchID_1');
         expect(fetch).toHaveBeenCalledTimes(5);
         expect(lobby.matches).toEqual([room1, room2]);
       });
       test('when the room does not exist', async () => {
         try {
-          await lobby.leave('game1', 'gameID_3');
+          await lobby.leave('game1', 'matchID_3');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
@@ -150,10 +150,10 @@ describe('lobby', () => {
         expect(lobby.matches).toEqual([room1, room2]);
       });
       test('when the player is not in the room', async () => {
-        await lobby.leave('game1', 'gameID_1');
+        await lobby.leave('game1', 'matchID_1');
         expect(fetch).toHaveBeenCalledTimes(5);
         try {
-          await lobby.leave('game1', 'gameID_1');
+          await lobby.leave('game1', 'matchID_1');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
@@ -161,7 +161,7 @@ describe('lobby', () => {
       test('when the server request fails', async () => {
         nextStatus = 404;
         try {
-          await lobby.leave('game1', 'gameID_1');
+          await lobby.leave('game1', 'matchID_1');
         } catch (error) {
           expect(error).toBeInstanceOf(Error);
         }
@@ -179,7 +179,7 @@ describe('lobby', () => {
         jsonResult.push(() => {
           return { playerCredentials: 'SECRET' };
         });
-        await lobby.join('game1', 'gameID_1', '0');
+        await lobby.join('game1', 'matchID_1', '0');
         // result of request 'leave'
         jsonResult.push(() => {
           return {};

--- a/src/lobby/create-match-form.js
+++ b/src/lobby/create-match-form.js
@@ -9,10 +9,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class LobbyCreateRoomForm extends React.Component {
+class LobbyCreateMatchForm extends React.Component {
   static propTypes = {
     games: PropTypes.array.isRequired,
-    createGame: PropTypes.func.isRequired,
+    createMatch: PropTypes.func.isRequired,
   };
 
   state = {
@@ -24,14 +24,14 @@ class LobbyCreateRoomForm extends React.Component {
     super(props);
     /* fix min and max number of players */
     for (let game of props.games) {
-      let game_details = game.game;
-      if (!game_details.minPlayers) {
-        game_details.minPlayers = 1;
+      let matchDetails = game.game;
+      if (!matchDetails.minPlayers) {
+        matchDetails.minPlayers = 1;
       }
-      if (!game_details.maxPlayers) {
-        game_details.maxPlayers = 4;
+      if (!matchDetails.maxPlayers) {
+        matchDetails.maxPlayers = 4;
       }
-      console.assert(game_details.maxPlayers >= game_details.minPlayers);
+      console.assert(matchDetails.maxPlayers >= matchDetails.minPlayers);
     }
     this.state = {
       selectedGame: 0,
@@ -99,11 +99,11 @@ class LobbyCreateRoomForm extends React.Component {
   };
 
   onClickCreate = () => {
-    this.props.createGame(
+    this.props.createMatch(
       this.props.games[this.state.selectedGame].game.name,
       this.state.numPlayers
     );
   };
 }
 
-export default LobbyCreateRoomForm;
+export default LobbyCreateMatchForm;

--- a/src/lobby/match-instance.js
+++ b/src/lobby/match-instance.js
@@ -9,9 +9,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class LobbyRoomInstance extends React.Component {
+class LobbyMatchInstance extends React.Component {
   static propTypes = {
-    room: PropTypes.shape({
+    match: PropTypes.shape({
       gameName: PropTypes.string.isRequired,
       matchID: PropTypes.string.isRequired,
       players: PropTypes.array.isRequired,
@@ -81,14 +81,14 @@ class LobbyRoomInstance extends React.Component {
     );
     const freeSeat = inst.players.find(player => !player.name);
     if (playerSeat && freeSeat) {
-      // already seated: waiting for game to start
+      // already seated: waiting for match to start
       return this._createButtonLeave(inst);
     }
     if (freeSeat) {
       // at least 1 seat is available
       return this._createButtonJoin(inst, freeSeat.id);
     }
-    // room is full
+    // match is full
     if (playerSeat) {
       return (
         <div>
@@ -104,24 +104,24 @@ class LobbyRoomInstance extends React.Component {
   };
 
   render() {
-    const room = this.props.room;
+    const match = this.props.match;
     let status = 'OPEN';
-    if (!room.players.find(player => !player.name)) {
+    if (!match.players.find(player => !player.name)) {
       status = 'RUNNING';
     }
     return (
-      <tr key={'line-' + room.matchID}>
-        <td key={'cell-name-' + room.matchID}>{room.gameName}</td>
-        <td key={'cell-status-' + room.matchID}>{status}</td>
-        <td key={'cell-seats-' + room.matchID}>
-          {room.players.map(this._createSeat).join(', ')}
+      <tr key={'line-' + match.matchID}>
+        <td key={'cell-name-' + match.matchID}>{match.gameName}</td>
+        <td key={'cell-status-' + match.matchID}>{status}</td>
+        <td key={'cell-seats-' + match.matchID}>
+          {match.players.map(this._createSeat).join(', ')}
         </td>
-        <td key={'cell-buttons-' + room.matchID}>
-          {this._createInstanceButtons(room)}
+        <td key={'cell-buttons-' + match.matchID}>
+          {this._createInstanceButtons(match)}
         </td>
       </tr>
     );
   }
 }
 
-export default LobbyRoomInstance;
+export default LobbyMatchInstance;

--- a/src/lobby/react.js
+++ b/src/lobby/react.js
@@ -146,9 +146,9 @@ class Lobby extends React.Component {
     }
   };
 
-  _joinRoom = async (gameName, gameID, playerID) => {
+  _joinRoom = async (gameName, matchID, playerID) => {
     try {
-      await this.connection.join(gameName, gameID, playerID);
+      await this.connection.join(gameName, matchID, playerID);
       await this.connection.refresh();
       this._updateCredentials(
         this.connection.playerName,
@@ -159,9 +159,9 @@ class Lobby extends React.Component {
     }
   };
 
-  _leaveRoom = async (gameName, gameID) => {
+  _leaveRoom = async (gameName, matchID) => {
     try {
-      await this.connection.leave(gameName, gameID);
+      await this.connection.leave(gameName, matchID);
       await this.connection.refresh();
       this._updateCredentials(
         this.connection.playerName,
@@ -208,7 +208,7 @@ class Lobby extends React.Component {
 
     const game = {
       app: app,
-      gameID: gameOpts.gameID,
+      matchID: gameOpts.matchID,
       playerID: gameOpts.numPlayers > 1 ? gameOpts.playerID : '0',
       credentials: this.connection.playerCredentials,
     };
@@ -226,11 +226,11 @@ class Lobby extends React.Component {
 
   renderRooms = (matches, playerName) => {
     return matches.map(room => {
-      const { gameID, gameName, players } = room;
+      const { matchID, gameName, players } = room;
       return (
         <LobbyRoomInstance
-          key={'instance-' + gameID}
-          room={{ gameID, gameName, players: Object.values(players) }}
+          key={'instance-' + matchID}
+          room={{ matchID, gameName, players: Object.values(players) }}
           playerName={playerName}
           onClickJoin={this._joinRoom}
           onClickLeave={this._leaveRoom}
@@ -303,7 +303,7 @@ class Lobby extends React.Component {
         <div className={this._getPhaseVisibility(LobbyPhases.PLAY)}>
           {runningGame && (
             <runningGame.app
-              gameID={runningGame.gameID}
+              matchID={runningGame.matchID}
               playerID={runningGame.playerID}
               credentials={runningGame.credentials}
             />

--- a/src/lobby/react.js
+++ b/src/lobby/react.js
@@ -224,8 +224,8 @@ class Lobby extends React.Component {
     return this.state.phase !== phase ? 'hidden' : 'phase';
   };
 
-  renderRooms = (rooms, playerName) => {
-    return rooms.map(room => {
+  renderRooms = (matches, playerName) => {
+    return matches.map(room => {
       const { gameID, gameName, players } = room;
       return (
         <LobbyRoomInstance
@@ -248,7 +248,7 @@ class Lobby extends React.Component {
       return renderer({
         errorMsg,
         gameComponents,
-        rooms: this.connection.rooms,
+        matches: this.connection.matches,
         phase,
         playerName,
         runningGame,
@@ -287,7 +287,7 @@ class Lobby extends React.Component {
           <div id="instances">
             <table>
               <tbody>
-                {this.renderRooms(this.connection.rooms, playerName)}
+                {this.renderRooms(this.connection.matches, playerName)}
               </tbody>
             </table>
             <span className="error-msg">

--- a/src/lobby/react.js
+++ b/src/lobby/react.js
@@ -15,8 +15,8 @@ import { Local } from '../client/transport/local';
 import { SocketIO } from '../client/transport/socketio';
 import { LobbyConnection } from './connection';
 import LobbyLoginForm from './login-form';
-import LobbyRoomInstance from './room-instance';
-import LobbyCreateRoomForm from './create-room-form';
+import LobbyMatchInstance from './match-instance';
+import LobbyCreateMatchForm from './create-match-form';
 
 const LobbyPhases = {
   ENTER: 'enter',
@@ -39,7 +39,8 @@ const LobbyPhases = {
  * @param {bool}   debug - Enable debug information (default: false).
  *
  * Returns:
- *   A React component that provides a UI to create, list, join, leave, play or spectate game instances.
+ *   A React component that provides a UI to create, list, join, leave, play or
+ *   spectate matches (game instances).
  */
 class Lobby extends React.Component {
   static propTypes = {
@@ -60,7 +61,7 @@ class Lobby extends React.Component {
   state = {
     phase: LobbyPhases.ENTER,
     playerName: 'Visitor',
-    runningGame: null,
+    runningMatch: null,
     errorMsg: '',
     credentialStore: {},
   };
@@ -135,7 +136,7 @@ class Lobby extends React.Component {
     this.setState({ phase: LobbyPhases.ENTER, errorMsg: '' });
   };
 
-  _createRoom = async (gameName, numPlayers) => {
+  _createMatch = async (gameName, numPlayers) => {
     try {
       await this.connection.create(gameName, numPlayers);
       await this.connection.refresh();
@@ -146,7 +147,7 @@ class Lobby extends React.Component {
     }
   };
 
-  _joinRoom = async (gameName, matchID, playerID) => {
+  _joinMatch = async (gameName, matchID, playerID) => {
     try {
       await this.connection.join(gameName, matchID, playerID);
       await this.connection.refresh();
@@ -159,7 +160,7 @@ class Lobby extends React.Component {
     }
   };
 
-  _leaveRoom = async (gameName, matchID) => {
+  _leaveMatch = async (gameName, matchID) => {
     try {
       await this.connection.leave(gameName, matchID);
       await this.connection.refresh();
@@ -172,7 +173,7 @@ class Lobby extends React.Component {
     }
   };
 
-  _startGame = (gameName, gameOpts) => {
+  _startMatch = (gameName, matchOpts) => {
     const gameCode = this.connection._getGameComponents(gameName);
     if (!gameCode) {
       this.setState({
@@ -182,7 +183,7 @@ class Lobby extends React.Component {
     }
 
     let multiplayer = undefined;
-    if (gameOpts.numPlayers > 1) {
+    if (matchOpts.numPlayers > 1) {
       if (this.props.gameServer) {
         multiplayer = SocketIO({ server: this.props.gameServer });
       } else {
@@ -190,7 +191,7 @@ class Lobby extends React.Component {
       }
     }
 
-    if (gameOpts.numPlayers == 1) {
+    if (matchOpts.numPlayers == 1) {
       const maxPlayers = gameCode.game.maxPlayers;
       let bots = {};
       for (let i = 1; i < maxPlayers; i++) {
@@ -206,35 +207,35 @@ class Lobby extends React.Component {
       multiplayer,
     });
 
-    const game = {
+    const match = {
       app: app,
-      matchID: gameOpts.matchID,
-      playerID: gameOpts.numPlayers > 1 ? gameOpts.playerID : '0',
+      matchID: matchOpts.matchID,
+      playerID: matchOpts.numPlayers > 1 ? matchOpts.playerID : '0',
       credentials: this.connection.playerCredentials,
     };
 
-    this.setState({ phase: LobbyPhases.PLAY, runningGame: game });
+    this.setState({ phase: LobbyPhases.PLAY, runningMatch: match });
   };
 
-  _exitRoom = () => {
-    this.setState({ phase: LobbyPhases.LIST, runningGame: null });
+  _exitMatch = () => {
+    this.setState({ phase: LobbyPhases.LIST, runningMatch: null });
   };
 
   _getPhaseVisibility = phase => {
     return this.state.phase !== phase ? 'hidden' : 'phase';
   };
 
-  renderRooms = (matches, playerName) => {
-    return matches.map(room => {
-      const { matchID, gameName, players } = room;
+  renderMatches = (matches, playerName) => {
+    return matches.map(match => {
+      const { matchID, gameName, players } = match;
       return (
-        <LobbyRoomInstance
+        <LobbyMatchInstance
           key={'instance-' + matchID}
-          room={{ matchID, gameName, players: Object.values(players) }}
+          match={{ matchID, gameName, players: Object.values(players) }}
           playerName={playerName}
-          onClickJoin={this._joinRoom}
-          onClickLeave={this._leaveRoom}
-          onClickPlay={this._startGame}
+          onClickJoin={this._joinMatch}
+          onClickLeave={this._leaveMatch}
+          onClickPlay={this._startMatch}
         />
       );
     });
@@ -242,7 +243,7 @@ class Lobby extends React.Component {
 
   render() {
     const { gameComponents, renderer } = this.props;
-    const { errorMsg, playerName, phase, runningGame } = this.state;
+    const { errorMsg, playerName, phase, runningMatch } = this.state;
 
     if (renderer) {
       return renderer({
@@ -251,15 +252,15 @@ class Lobby extends React.Component {
         matches: this.connection.matches,
         phase,
         playerName,
-        runningGame,
+        runningMatch,
         handleEnterLobby: this._enterLobby,
         handleExitLobby: this._exitLobby,
-        handleCreateRoom: this._createRoom,
-        handleJoinRoom: this._joinRoom,
-        handleLeaveRoom: this._leaveRoom,
-        handleExitRoom: this._exitRoom,
-        handleRefreshRooms: this._updateConnection,
-        handleStartGame: this._startGame,
+        handleCreateMatch: this._createMatch,
+        handleJoinMatch: this._joinMatch,
+        handleLeaveMatch: this._leaveMatch,
+        handleExitMatch: this._exitMatch,
+        handleRefreshMatches: this._updateConnection,
+        handleStartMatch: this._startMatch,
       });
     }
 
@@ -276,18 +277,18 @@ class Lobby extends React.Component {
         <div className={this._getPhaseVisibility(LobbyPhases.LIST)}>
           <p>Welcome, {playerName}</p>
 
-          <div className="phase-title" id="game-creation">
-            <span>Create a room:</span>
-            <LobbyCreateRoomForm
+          <div className="phase-title" id="match-creation">
+            <span>Create a match:</span>
+            <LobbyCreateMatchForm
               games={gameComponents}
-              createGame={this._createRoom}
+              createMatch={this._createMatch}
             />
           </div>
-          <p className="phase-title">Join a room:</p>
+          <p className="phase-title">Join a match:</p>
           <div id="instances">
             <table>
               <tbody>
-                {this.renderRooms(this.connection.matches, playerName)}
+                {this.renderMatches(this.connection.matches, playerName)}
               </tbody>
             </table>
             <span className="error-msg">
@@ -296,20 +297,20 @@ class Lobby extends React.Component {
             </span>
           </div>
           <p className="phase-title">
-            Rooms that become empty are automatically deleted.
+            Matches that become empty are automatically deleted.
           </p>
         </div>
 
         <div className={this._getPhaseVisibility(LobbyPhases.PLAY)}>
-          {runningGame && (
-            <runningGame.app
-              matchID={runningGame.matchID}
-              playerID={runningGame.playerID}
-              credentials={runningGame.credentials}
+          {runningMatch && (
+            <runningMatch.app
+              matchID={runningMatch.matchID}
+              playerID={runningMatch.playerID}
+              credentials={runningMatch.credentials}
             />
           )}
-          <div className="buttons" id="game-exit">
-            <button onClick={this._exitRoom}>Exit game</button>
+          <div className="buttons" id="match-exit">
+            <button onClick={this._exitMatch}>Exit match</button>
           </div>
         </div>
 

--- a/src/lobby/react.test.js
+++ b/src/lobby/react.test.js
@@ -131,7 +131,7 @@ describe('lobby', () => {
       beforeEach(async () => {
         lobby.instance().connection.matches = [
           {
-            gameID: 'gameID1',
+            matchID: 'matchID1',
             players: {
               '0': { id: 0, name: 'Bob' },
               '1': { id: 1 },
@@ -200,7 +200,7 @@ describe('lobby', () => {
       beforeEach(async () => {
         lobby.instance().connection.matches = [
           {
-            gameID: 'gameID1',
+            matchID: 'matchID1',
             players: { '0': { id: 0 } },
             gameName: 'GameName1',
           },
@@ -283,12 +283,12 @@ describe('lobby', () => {
       beforeEach(async () => {
         lobby.instance().connection.matches = [
           {
-            gameID: 'gameID1',
+            matchID: 'matchID1',
             players: { '0': { id: 0 } },
             gameName: 'GameName1',
           },
           {
-            gameID: 'gameID2',
+            matchID: 'matchID2',
             players: { '0': { id: 0, name: 'Bob' } },
             gameName: 'GameName1',
           },
@@ -304,7 +304,7 @@ describe('lobby', () => {
           .first()
           .find('button')
           .simulate('click');
-        expect(spy).toHaveBeenCalledWith('GameName1', 'gameID1', '0');
+        expect(spy).toHaveBeenCalledWith('GameName1', 'matchID1', '0');
       });
       test('when room is full', () => {
         // try 2nd room
@@ -338,7 +338,7 @@ describe('lobby', () => {
       beforeEach(async () => {
         lobby.instance().connection.matches = [
           {
-            gameID: 'gameID1',
+            matchID: 'matchID1',
             players: {
               '0': { id: 0, name: 'Bob' },
               '1': { id: 1 },
@@ -362,7 +362,7 @@ describe('lobby', () => {
           .find('LobbyRoomInstance')
           .find('button')
           .simulate('click');
-        expect(spy).toHaveBeenCalledWith('GameName1', 'gameID1');
+        expect(spy).toHaveBeenCalledWith('GameName1', 'matchID1');
       });
       test('when server request fails', async () => {
         lobby.instance().connection.leave = spy.mockImplementation(() => {
@@ -385,7 +385,7 @@ describe('lobby', () => {
       beforeEach(async () => {
         lobby.instance().connection.matches = [
           {
-            gameID: 'gameID1',
+            matchID: 'matchID1',
             players: {
               '0': { id: 0, name: 'Bob', credentials: 'SECRET1' },
               '1': { id: 1, name: 'Charly', credentials: 'SECRET2' },
@@ -393,17 +393,17 @@ describe('lobby', () => {
             gameName: 'GameName1',
           },
           {
-            gameID: 'gameID2',
+            matchID: 'matchID2',
             players: { '0': { id: 0, name: 'Alice' } },
             gameName: 'GameName2',
           },
           {
-            gameID: 'gameID3',
+            matchID: 'matchID3',
             players: { '0': { id: 0, name: 'Bob' } },
             gameName: 'GameName3',
           },
           {
-            gameID: 'gameID4',
+            matchID: 'matchID4',
             players: { '0': { id: 0, name: 'Zoe' } },
             gameName: 'GameNameUnknown',
           },
@@ -423,7 +423,7 @@ describe('lobby', () => {
           .simulate('click');
         expect(lobby.instance().state.runningGame).toEqual({
           app: NullComponent,
-          gameID: 'gameID1',
+          matchID: 'matchID1',
           playerID: '0',
           credentials: 'SECRET1',
         });
@@ -444,7 +444,7 @@ describe('lobby', () => {
         expect(lobby.instance().state.runningGame).toEqual({
           app: NullComponent,
           credentials: undefined,
-          gameID: 'gameID2',
+          matchID: 'matchID2',
           playerID: '0',
         });
       });
@@ -473,7 +473,7 @@ describe('lobby', () => {
           .first()
           .simulate('click');
         expect(spy).not.toHaveBeenCalledWith(expect.anything(), {
-          gameID: 'gameID3',
+          matchID: 'matchID3',
         });
       });
     });
@@ -482,7 +482,7 @@ describe('lobby', () => {
       beforeEach(async () => {
         lobby.instance().connection.matches = [
           {
-            gameID: 'gameID1',
+            matchID: 'matchID1',
             players: {
               '0': { id: 0, name: 'Bob', credentials: 'SECRET1' },
               '1': { id: 1, name: 'Charly', credentials: 'SECRET2' },

--- a/src/lobby/react.test.js
+++ b/src/lobby/react.test.js
@@ -129,7 +129,7 @@ describe('lobby', () => {
 
     describe('exiting lobby', () => {
       beforeEach(async () => {
-        lobby.instance().connection.rooms = [
+        lobby.instance().connection.matches = [
           {
             gameID: 'gameID1',
             players: {
@@ -171,7 +171,7 @@ describe('lobby', () => {
     });
   });
 
-  describe('rooms list', () => {
+  describe('matches list', () => {
     let spyClient = jest.fn();
     beforeEach(async () => {
       // initial state = logged-in as 'Bob'
@@ -198,7 +198,7 @@ describe('lobby', () => {
 
     describe('creating a room', () => {
       beforeEach(async () => {
-        lobby.instance().connection.rooms = [
+        lobby.instance().connection.matches = [
           {
             gameID: 'gameID1',
             players: { '0': { id: 0 } },
@@ -281,7 +281,7 @@ describe('lobby', () => {
 
     describe('joining a room', () => {
       beforeEach(async () => {
-        lobby.instance().connection.rooms = [
+        lobby.instance().connection.matches = [
           {
             gameID: 'gameID1',
             players: { '0': { id: 0 } },
@@ -336,7 +336,7 @@ describe('lobby', () => {
 
     describe('leaving a room', () => {
       beforeEach(async () => {
-        lobby.instance().connection.rooms = [
+        lobby.instance().connection.matches = [
           {
             gameID: 'gameID1',
             players: {
@@ -383,7 +383,7 @@ describe('lobby', () => {
 
     describe('starting a game', () => {
       beforeEach(async () => {
-        lobby.instance().connection.rooms = [
+        lobby.instance().connection.matches = [
           {
             gameID: 'gameID1',
             players: {
@@ -480,7 +480,7 @@ describe('lobby', () => {
 
     describe('exiting during game', () => {
       beforeEach(async () => {
-        lobby.instance().connection.rooms = [
+        lobby.instance().connection.matches = [
           {
             gameID: 'gameID1',
             players: {

--- a/src/lobby/react.test.js
+++ b/src/lobby/react.test.js
@@ -55,7 +55,7 @@ describe('lobby', () => {
           gameServer="localhost:9000"
         />
       );
-      lobby.instance()._startGame('GameName1', { numPlayers: 2 });
+      lobby.instance()._startMatch('GameName1', { numPlayers: 2 });
       expect(spy).toBeCalledWith(
         expect.objectContaining({
           multiplayer: expect.anything(),
@@ -196,7 +196,7 @@ describe('lobby', () => {
       spyClient.mockReset();
     });
 
-    describe('creating a room', () => {
+    describe('creating a match', () => {
       beforeEach(async () => {
         lobby.instance().connection.matches = [
           {
@@ -209,30 +209,30 @@ describe('lobby', () => {
         lobby.update();
       });
 
-      test('room with default number of players', () => {
+      test('match with default number of players', () => {
         lobby.instance().connection.create = spy;
         lobby
-          .find('LobbyCreateRoomForm')
+          .find('LobbyCreateMatchForm')
           .find('button')
           .simulate('click');
         expect(spy).toHaveBeenCalledWith('GameName1', 3);
       });
-      test('room with 2 players', () => {
+      test('match with 2 players', () => {
         lobby.instance().connection.create = spy;
         lobby
-          .find('LobbyCreateRoomForm')
+          .find('LobbyCreateMatchForm')
           .find('select')
           .first()
           .props()
           .onChange({ target: { value: '1' } });
         lobby
-          .find('LobbyCreateRoomForm')
+          .find('LobbyCreateMatchForm')
           .find('select')
           .at(1)
           .props()
           .onChange({ target: { value: '2' } });
         lobby
-          .find('LobbyCreateRoomForm')
+          .find('LobbyCreateMatchForm')
           .find('button')
           .simulate('click');
         expect(spy).toHaveBeenCalledWith('GameName2', 2);
@@ -242,7 +242,7 @@ describe('lobby', () => {
           throw new Error('fail');
         });
         await lobby
-          .find('LobbyCreateRoomForm')
+          .find('LobbyCreateMatchForm')
           .find('button')
           .simulate('click');
         expect(
@@ -255,14 +255,14 @@ describe('lobby', () => {
       test('when game has no boundaries on the number of players', async () => {
         // select 2nd game
         lobby
-          .find('LobbyCreateRoomForm')
+          .find('LobbyCreateMatchForm')
           .find('select')
           .first()
           .props()
           .onChange({ target: { value: '1' } });
         expect(
           lobby
-            .find('LobbyCreateRoomForm')
+            .find('LobbyCreateMatchForm')
             .find('select')
             .at(1)
             .text()
@@ -271,7 +271,7 @@ describe('lobby', () => {
       test('when game has boundaries on the number of players', async () => {
         expect(
           lobby
-            .find('LobbyCreateRoomForm')
+            .find('LobbyCreateMatchForm')
             .find('select')
             .at(1)
             .text()
@@ -279,7 +279,7 @@ describe('lobby', () => {
       });
     });
 
-    describe('joining a room', () => {
+    describe('joining a match', () => {
       beforeEach(async () => {
         lobby.instance().connection.matches = [
           {
@@ -296,21 +296,21 @@ describe('lobby', () => {
         lobby.instance().forceUpdate();
         lobby.update();
       });
-      test('when room is empty', () => {
-        // join 1st room
+      test('when match is empty', () => {
+        // join 1st match
         lobby.instance().connection.join = spy;
         lobby
-          .find('LobbyRoomInstance')
+          .find('LobbyMatchInstance')
           .first()
           .find('button')
           .simulate('click');
         expect(spy).toHaveBeenCalledWith('GameName1', 'matchID1', '0');
       });
-      test('when room is full', () => {
-        // try 2nd room
+      test('when match is full', () => {
+        // try 2nd match
         expect(
           lobby
-            .find('LobbyRoomInstance')
+            .find('LobbyMatchInstance')
             .at(1)
             .text()
         ).toContain('RUNNING');
@@ -319,9 +319,9 @@ describe('lobby', () => {
         lobby.instance().connection.join = spy.mockImplementation(() => {
           throw new Error('fail');
         });
-        // join 1st room
+        // join 1st match
         await lobby
-          .find('LobbyRoomInstance')
+          .find('LobbyMatchInstance')
           .first()
           .find('button')
           .simulate('click');
@@ -334,7 +334,7 @@ describe('lobby', () => {
       });
     });
 
-    describe('leaving a room', () => {
+    describe('leaving a match', () => {
       beforeEach(async () => {
         lobby.instance().connection.matches = [
           {
@@ -350,16 +350,16 @@ describe('lobby', () => {
         lobby.update();
         expect(
           lobby
-            .find('LobbyRoomInstance')
+            .find('LobbyMatchInstance')
             .find('button')
             .text()
         ).toBe('Leave');
       });
-      test('shall leave a room', () => {
-        // leave room
+      test('shall leave a match', () => {
+        // leave match
         lobby.instance().connection.leave = spy;
         lobby
-          .find('LobbyRoomInstance')
+          .find('LobbyMatchInstance')
           .find('button')
           .simulate('click');
         expect(spy).toHaveBeenCalledWith('GameName1', 'matchID1');
@@ -369,7 +369,7 @@ describe('lobby', () => {
           throw new Error('fail');
         });
         await lobby
-          .find('LobbyRoomInstance')
+          .find('LobbyMatchInstance')
           .find('button')
           .simulate('click');
         expect(
@@ -415,13 +415,13 @@ describe('lobby', () => {
       test('if player has joined the game', () => {
         lobby.instance().connection.playerCredentials = 'SECRET1';
         lobby
-          .find('LobbyRoomInstance')
+          .find('LobbyMatchInstance')
           .first()
           .find('button')
 
           .first()
           .simulate('click');
-        expect(lobby.instance().state.runningGame).toEqual({
+        expect(lobby.instance().state.runningMatch).toEqual({
           app: NullComponent,
           matchID: 'matchID1',
           playerID: '0',
@@ -437,11 +437,11 @@ describe('lobby', () => {
 
       test('if player is spectator', () => {
         lobby
-          .find('LobbyRoomInstance')
+          .find('LobbyMatchInstance')
           .at(1)
           .find('button')
           .simulate('click');
-        expect(lobby.instance().state.runningGame).toEqual({
+        expect(lobby.instance().state.runningMatch).toEqual({
           app: NullComponent,
           credentials: undefined,
           matchID: 'matchID2',
@@ -451,7 +451,7 @@ describe('lobby', () => {
 
       test('if game is not supported', () => {
         lobby
-          .find('LobbyRoomInstance')
+          .find('LobbyMatchInstance')
           .at(3)
           .find('button')
           .simulate('click');
@@ -466,7 +466,7 @@ describe('lobby', () => {
 
       test('if game is monoplayer', () => {
         lobby
-          .find('LobbyRoomInstance')
+          .find('LobbyMatchInstance')
           .at(2)
           .find('button')
 
@@ -497,17 +497,17 @@ describe('lobby', () => {
         lobby.instance().connection.playerCredentials = 'SECRET1';
         // start game
         lobby
-          .find('LobbyRoomInstance')
+          .find('LobbyMatchInstance')
           .first()
           .find('button')
           .first()
           .simulate('click');
         // exit game
         lobby
-          .find('#game-exit')
+          .find('#match-exit')
           .find('button')
           .simulate('click');
-        expect(lobby.instance().state.runningGame).toEqual(null);
+        expect(lobby.instance().state.runningMatch).toEqual(null);
         expect(lobby.instance().state.phase).toEqual('list');
       });
     });

--- a/src/lobby/room-instance.js
+++ b/src/lobby/room-instance.js
@@ -13,7 +13,7 @@ class LobbyRoomInstance extends React.Component {
   static propTypes = {
     room: PropTypes.shape({
       gameName: PropTypes.string.isRequired,
-      gameID: PropTypes.string.isRequired,
+      matchID: PropTypes.string.isRequired,
       players: PropTypes.array.isRequired,
     }),
     playerName: PropTypes.string.isRequired,
@@ -28,9 +28,9 @@ class LobbyRoomInstance extends React.Component {
 
   _createButtonJoin = (inst, seatId) => (
     <button
-      key={'button-join-' + inst.gameID}
+      key={'button-join-' + inst.matchID}
       onClick={() =>
-        this.props.onClickJoin(inst.gameName, inst.gameID, '' + seatId)
+        this.props.onClickJoin(inst.gameName, inst.matchID, '' + seatId)
       }
     >
       Join
@@ -39,8 +39,8 @@ class LobbyRoomInstance extends React.Component {
 
   _createButtonLeave = inst => (
     <button
-      key={'button-leave-' + inst.gameID}
-      onClick={() => this.props.onClickLeave(inst.gameName, inst.gameID)}
+      key={'button-leave-' + inst.matchID}
+      onClick={() => this.props.onClickLeave(inst.gameName, inst.matchID)}
     >
       Leave
     </button>
@@ -48,10 +48,10 @@ class LobbyRoomInstance extends React.Component {
 
   _createButtonPlay = (inst, seatId) => (
     <button
-      key={'button-play-' + inst.gameID}
+      key={'button-play-' + inst.matchID}
       onClick={() =>
         this.props.onClickPlay(inst.gameName, {
-          gameID: inst.gameID,
+          matchID: inst.matchID,
           playerID: '' + seatId,
           numPlayers: inst.players.length,
         })
@@ -63,10 +63,10 @@ class LobbyRoomInstance extends React.Component {
 
   _createButtonSpectate = inst => (
     <button
-      key={'button-spectate-' + inst.gameID}
+      key={'button-spectate-' + inst.matchID}
       onClick={() =>
         this.props.onClickPlay(inst.gameName, {
-          gameID: inst.gameID,
+          matchID: inst.matchID,
           numPlayers: inst.players.length,
         })
       }
@@ -110,13 +110,13 @@ class LobbyRoomInstance extends React.Component {
       status = 'RUNNING';
     }
     return (
-      <tr key={'line-' + room.gameID}>
-        <td key={'cell-name-' + room.gameID}>{room.gameName}</td>
-        <td key={'cell-status-' + room.gameID}>{status}</td>
-        <td key={'cell-seats-' + room.gameID}>
+      <tr key={'line-' + room.matchID}>
+        <td key={'cell-name-' + room.matchID}>{room.gameName}</td>
+        <td key={'cell-status-' + room.matchID}>{status}</td>
+        <td key={'cell-seats-' + room.matchID}>
           {room.players.map(this._createSeat).join(', ')}
         </td>
-        <td key={'cell-buttons-' + room.gameID}>
+        <td key={'cell-buttons-' + room.matchID}>
           {this._createInstanceButtons(room)}
         </td>
       </tr>

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -12,7 +12,7 @@ import {
   Master,
   redactLog,
   getPlayerMetadata,
-  doesGameRequireAuthentication,
+  doesMatchRequireAuthentication,
   isActionFromAuthenticPlayer,
 } from './master';
 import { error } from '../core/logger';
@@ -619,10 +619,10 @@ describe('getPlayerMetadata', () => {
   });
 });
 
-describe('doesGameRequireAuthentication', () => {
+describe('doesMatchRequireAuthentication', () => {
   describe('when game metadata is not found', () => {
     test('then authentication is not required', () => {
-      const result = doesGameRequireAuthentication();
+      const result = doesMatchRequireAuthentication();
       expect(result).toBe(false);
     });
   });
@@ -636,7 +636,7 @@ describe('doesGameRequireAuthentication', () => {
           '0': { id: 1 },
         },
       };
-      const result = doesGameRequireAuthentication(matchMetadata);
+      const result = doesMatchRequireAuthentication(matchMetadata);
       expect(result).toBe(false);
     });
   });
@@ -653,7 +653,7 @@ describe('doesGameRequireAuthentication', () => {
           },
         },
       };
-      const result = doesGameRequireAuthentication(matchMetadata);
+      const result = doesMatchRequireAuthentication(matchMetadata);
       expect(result).toBe(true);
     });
   });

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -590,7 +590,9 @@ describe('getPlayerMetadata', () => {
 
   describe('when metadata does not contain players field', () => {
     test('then playerMetadata is undefined', () => {
-      expect(getPlayerMetadata({} as Server.GameMetadata, '0')).toBeUndefined();
+      expect(
+        getPlayerMetadata({} as Server.MatchMetadata, '0')
+      ).toBeUndefined();
     });
   });
 
@@ -627,21 +629,21 @@ describe('doesGameRequireAuthentication', () => {
 
   describe('when game has no credentials', () => {
     test('then authentication is not required', () => {
-      const gameMetadata = {
+      const matchMetadata = {
         gameName: '',
         setupData: {},
         players: {
           '0': { id: 1 },
         },
       };
-      const result = doesGameRequireAuthentication(gameMetadata);
+      const result = doesGameRequireAuthentication(matchMetadata);
       expect(result).toBe(false);
     });
   });
 
   describe('when game has credentials', () => {
     test('then authentication is required', () => {
-      const gameMetadata = {
+      const matchMetadata = {
         gameName: '',
         setupData: {},
         players: {
@@ -651,7 +653,7 @@ describe('doesGameRequireAuthentication', () => {
           },
         },
       };
-      const result = doesGameRequireAuthentication(gameMetadata);
+      const result = doesGameRequireAuthentication(matchMetadata);
       expect(result).toBe(true);
     });
   });
@@ -660,7 +662,7 @@ describe('doesGameRequireAuthentication', () => {
 describe('isActionFromAuthenticPlayer', () => {
   let action;
   let playerID;
-  let gameMetadata;
+  let matchMetadata;
   let credentials;
   let playerMetadata;
 
@@ -671,13 +673,13 @@ describe('isActionFromAuthenticPlayer', () => {
       payload: { credentials: 'SECRET' },
     };
 
-    gameMetadata = {
+    matchMetadata = {
       players: {
         '0': { credentials: 'SECRET' },
       },
     };
 
-    playerMetadata = gameMetadata.players[playerID];
+    playerMetadata = matchMetadata.players[playerID];
     ({ credentials } = action.payload || {});
   });
 

--- a/src/master/master.test.ts
+++ b/src/master/master.test.ts
@@ -627,7 +627,7 @@ describe('doesGameRequireAuthentication', () => {
     });
   });
 
-  describe('when game has no credentials', () => {
+  describe('when match has no credentials', () => {
     test('then authentication is not required', () => {
       const matchMetadata = {
         gameName: '',
@@ -641,7 +641,7 @@ describe('doesGameRequireAuthentication', () => {
     });
   });
 
-  describe('when game has credentials', () => {
+  describe('when match has credentials', () => {
     test('then authentication is required', () => {
       const matchMetadata = {
         gameName: '',

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -80,7 +80,7 @@ export function redactLog(log: LogEntry[], playerID: PlayerID) {
 /**
  * Verifies that the match has metadata and is using credentials.
  */
-export const doesGameRequireAuthentication = (
+export const doesMatchRequireAuthentication = (
   matchMetadata?: Server.MatchMetadata
 ) => {
   if (!matchMetadata) return false;
@@ -136,7 +136,7 @@ export class Master {
   transportAPI;
   subscribeCallback: CallbackFn;
   auth: null | AuthFn;
-  shouldAuth: typeof doesGameRequireAuthentication;
+  shouldAuth: typeof doesMatchRequireAuthentication;
 
   constructor(
     game: Game,
@@ -153,7 +153,7 @@ export class Master {
 
     if (auth === true) {
       this.auth = isActionFromAuthenticPlayer;
-      this.shouldAuth = doesGameRequireAuthentication;
+      this.shouldAuth = doesMatchRequireAuthentication;
     } else if (typeof auth === 'function') {
       this.auth = auth;
       this.shouldAuth = () => true;

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -26,11 +26,11 @@ import {
 import * as StorageAPI from '../server/db/base';
 
 export const getPlayerMetadata = (
-  gameMetadata: Server.GameMetadata,
+  matchMetadata: Server.MatchMetadata,
   playerID: PlayerID
 ) => {
-  if (gameMetadata && gameMetadata.players) {
-    return gameMetadata.players[playerID];
+  if (matchMetadata && matchMetadata.players) {
+    return matchMetadata.players[playerID];
   }
 };
 
@@ -81,10 +81,10 @@ export function redactLog(log: LogEntry[], playerID: PlayerID) {
  * Verifies that the game has metadata and is using credentials.
  */
 export const doesGameRequireAuthentication = (
-  gameMetadata?: Server.GameMetadata
+  matchMetadata?: Server.MatchMetadata
 ) => {
-  if (!gameMetadata) return false;
-  const { players } = gameMetadata as Server.GameMetadata;
+  if (!matchMetadata) return false;
+  const { players } = matchMetadata as Server.MatchMetadata;
   const hasCredentials = Object.keys(players).some(key => {
     return !!(players[key] && players[key].credentials);
   });
@@ -176,7 +176,7 @@ export class Master {
     playerID: string
   ) {
     let isActionAuthentic;
-    let metadata: Server.GameMetadata | undefined;
+    let metadata: Server.MatchMetadata | undefined;
     const credentials = credAction.payload.credentials;
     if (IsSynchronous(this.storageAPI)) {
       ({ metadata } = this.storageAPI.fetch(gameID, { metadata: true }));
@@ -290,7 +290,7 @@ export class Master {
 
     const { deltalog, ...stateWithoutDeltalog } = state;
 
-    let newMetadata: Server.GameMetadata | undefined;
+    let newMetadata: Server.MatchMetadata | undefined;
     if (
       metadata &&
       !('gameover' in metadata) &&
@@ -326,7 +326,7 @@ export class Master {
     let state: State;
     let initialState: State;
     let log: LogEntry[];
-    let gameMetadata: Server.GameMetadata;
+    let matchMetadata: Server.MatchMetadata;
     let filteredMetadata: FilteredMetadata;
     let result: StorageAPI.FetchResult<{
       state: true;
@@ -354,10 +354,10 @@ export class Master {
     state = result.state;
     initialState = result.initialState;
     log = result.log;
-    gameMetadata = result.metadata;
+    matchMetadata = result.metadata;
 
-    if (gameMetadata) {
-      filteredMetadata = Object.values(gameMetadata.players).map(player => {
+    if (matchMetadata) {
+      filteredMetadata = Object.values(matchMetadata.players).map(player => {
         const { credentials, ...filteredData } = player;
         return filteredData;
       });

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -78,7 +78,7 @@ export function redactLog(log: LogEntry[], playerID: PlayerID) {
 }
 
 /**
- * Verifies that the game has metadata and is using credentials.
+ * Verifies that the match has metadata and is using credentials.
  */
 export const doesGameRequireAuthentication = (
   matchMetadata?: Server.MatchMetadata

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -103,7 +103,7 @@ describe('.createRouter', () => {
       beforeEach(async () => {
         delete process.env.API_SECRET;
 
-        const uuid = () => 'gameID';
+        const uuid = () => 'matchID';
         app = createApiServer({ db, games, uuid });
 
         response = await request(app.callback())
@@ -117,7 +117,7 @@ describe('.createRouter', () => {
 
       test('creates game state and metadata', () => {
         expect(db.mocks.createGame).toHaveBeenCalledWith(
-          'gameID',
+          'matchID',
           expect.objectContaining({
             initialState: expect.objectContaining({
               ctx: expect.objectContaining({
@@ -137,7 +137,7 @@ describe('.createRouter', () => {
       });
 
       test('returns game id', () => {
-        expect(response.body.gameID).not.toBeNull();
+        expect(response.body.matchID).not.toBeNull();
       });
 
       describe('without numPlayers', () => {
@@ -147,7 +147,7 @@ describe('.createRouter', () => {
 
         test('uses default numPlayers', () => {
           expect(db.mocks.createGame).toHaveBeenCalledWith(
-            'gameID',
+            'matchID',
             expect.objectContaining({
               initialState: expect.objectContaining({
                 ctx: expect.objectContaining({
@@ -185,7 +185,7 @@ describe('.createRouter', () => {
 
         test('includes setupData in metadata', () => {
           expect(db.mocks.createGame).toHaveBeenCalledWith(
-            'gameID',
+            'matchID',
             expect.objectContaining({
               metadata: expect.objectContaining({
                 setupData: expect.objectContaining({
@@ -201,7 +201,7 @@ describe('.createRouter', () => {
 
         test('passes setupData to game setup function', () => {
           expect(db.mocks.createGame).toHaveBeenCalledWith(
-            'gameID',
+            'matchID',
             expect.objectContaining({
               initialState: expect.objectContaining({
                 G: expect.objectContaining({
@@ -225,7 +225,7 @@ describe('.createRouter', () => {
 
         test('sets unlisted in metadata', () => {
           expect(db.mocks.createGame).toHaveBeenCalledWith(
-            'gameID',
+            'matchID',
             expect.objectContaining({
               metadata: expect.objectContaining({
                 unlisted: true,
@@ -319,7 +319,7 @@ describe('.createRouter', () => {
             const app = createApiServer({
               db,
               games,
-              uuid: () => 'gameID',
+              uuid: () => 'matchID',
               generateCredentials: () => credentials,
             });
             response = await request(app.callback())
@@ -1132,7 +1132,7 @@ describe('.createRouter', () => {
     beforeEach(() => {
       delete process.env.API_SECRET;
       db = new AsyncStorage({
-        fetch: async gameID => {
+        fetch: async matchID => {
           return {
             metadata: {
               players: {
@@ -1145,8 +1145,8 @@ describe('.createRouter', () => {
                   credentials: 'SECRET2',
                 },
               },
-              unlisted: gameID === 'bar-4',
-              gameover: gameID === 'bar-3' ? { winner: 0 } : undefined,
+              unlisted: matchID === 'bar-4',
+              gameover: matchID === 'bar-3' ? { winner: 0 } : undefined,
             },
           };
         },

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -1053,7 +1053,7 @@ describe('.createRouter', () => {
           }),
         })
       );
-      expect(response.body.nextRoomID).toBe('newGameID');
+      expect(response.body.nextMatchID).toBe('newGameID');
     });
 
     test('fetches next id', async () => {
@@ -1071,7 +1071,7 @@ describe('.createRouter', () => {
                   credentials: 'SECRET2',
                 },
               },
-              nextRoomID: '12345',
+              nextMatchID: '12345',
             },
           };
         },
@@ -1080,7 +1080,7 @@ describe('.createRouter', () => {
       response = await request(app.callback())
         .post('/games/foo/1/playAgain')
         .send('playerID=0&credentials=SECRET1');
-      expect(response.body.nextRoomID).toBe('12345');
+      expect(response.body.nextMatchID).toBe('12345');
     });
 
     test('when the game does not exist throws a "not found" error', async () => {

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -1167,33 +1167,33 @@ describe('.createRouter', () => {
       });
     });
 
-    describe('when given 2 rooms', () => {
+    describe('when given 2 matches', () => {
       let response;
-      let rooms;
+      let matches;
       beforeEach(async () => {
         let games = [ProcessGameConfig({ name: 'foo' }), { name: 'bar' }];
         let app = createApiServer({ db, games });
         response = await request(app.callback()).get('/games/bar');
-        rooms = JSON.parse(response.text).rooms;
+        matches = JSON.parse(response.text).matches;
       });
 
-      test('returns rooms for the selected game', async () => {
-        expect(rooms).toHaveLength(2);
+      test('returns matches for the selected game', async () => {
+        expect(matches).toHaveLength(2);
       });
 
       test('returns room ids', async () => {
-        expect(rooms[0].gameID).toEqual('bar-2');
-        expect(rooms[1].gameID).toEqual('bar-3');
+        expect(matches[0].gameID).toEqual('bar-2');
+        expect(matches[1].gameID).toEqual('bar-3');
       });
 
       test('returns player names', async () => {
-        expect(rooms[0].players).toEqual([{ id: 0 }, { id: 1 }]);
-        expect(rooms[1].players).toEqual([{ id: 0 }, { id: 1 }]);
+        expect(matches[0].players).toEqual([{ id: 0 }, { id: 1 }]);
+        expect(matches[1].players).toEqual([{ id: 0 }, { id: 1 }]);
       });
 
       test('returns gameover data for ended game', async () => {
-        expect(rooms[0].gameover).toBeUndefined();
-        expect(rooms[1].gameover).toEqual({ winner: 0 });
+        expect(matches[0].gameover).toBeUndefined();
+        expect(matches[1].gameover).toEqual({ winner: 0 });
       });
     });
   });

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -608,7 +608,7 @@ describe('.createRouter', () => {
           response = await request(app.callback())
             .post('/games/foo/1/update')
             .send('playerID=0&playerName=alice&newName=ali');
-          expect(response.text).toEqual('Game 1 not found');
+          expect(response.text).toEqual('Match 1 not found');
         });
       });
 
@@ -739,7 +739,7 @@ describe('.createRouter', () => {
           response = await request(app.callback())
             .post('/games/foo/1/update')
             .send({ playerID: 0, data: { subdata: 'text' } });
-          expect(response.text).toEqual('Game 1 not found');
+          expect(response.text).toEqual('Match 1 not found');
         });
       });
 

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -136,7 +136,7 @@ describe('.createRouter', () => {
         );
       });
 
-      test('returns game id', () => {
+      test('returns match id', () => {
         expect(response.body.matchID).not.toBeNull();
       });
 
@@ -1083,7 +1083,7 @@ describe('.createRouter', () => {
       expect(response.body.nextMatchID).toBe('12345');
     });
 
-    test('when the game does not exist throws a "not found" error', async () => {
+    test('when the match does not exist throws a "not found" error', async () => {
       db = new AsyncStorage({
         fetch: async () => ({ metadata: null }),
       });
@@ -1181,7 +1181,7 @@ describe('.createRouter', () => {
         expect(matches).toHaveLength(2);
       });
 
-      test('returns room ids', async () => {
+      test('returns match ids', async () => {
         expect(matches[0].matchID).toEqual('bar-2');
         expect(matches[1].matchID).toEqual('bar-3');
       });
@@ -1191,7 +1191,7 @@ describe('.createRouter', () => {
         expect(matches[1].players).toEqual([{ id: 0 }, { id: 1 }]);
       });
 
-      test('returns gameover data for ended game', async () => {
+      test('returns gameover data for ended match', async () => {
         expect(matches[0].gameover).toBeUndefined();
         expect(matches[1].gameover).toEqual({ winner: 0 });
       });

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -1182,8 +1182,8 @@ describe('.createRouter', () => {
       });
 
       test('returns room ids', async () => {
-        expect(matches[0].gameID).toEqual('bar-2');
-        expect(matches[1].gameID).toEqual('bar-3');
+        expect(matches[0].matchID).toEqual('bar-2');
+        expect(matches[1].matchID).toEqual('bar-3');
       });
 
       test('returns player names', async () => {
@@ -1237,7 +1237,7 @@ describe('.createRouter', () => {
       });
 
       test('returns game ids', async () => {
-        expect(room.roomID).toEqual('bar-0');
+        expect(room.matchID).toEqual('bar-0');
       });
 
       test('returns player names', async () => {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -27,7 +27,7 @@ import { Server, Game } from '../types';
  * @param {object } lobbyConfig - Configuration options for the lobby.
  * @param {boolean} unlisted - Whether the game should be excluded from public listing.
  */
-export const CreateGame = async ({
+export const CreateMatch = async ({
   db,
   game,
   numPlayers,
@@ -116,7 +116,7 @@ export const createRouter = ({
     const game = games.find(g => g.name === gameName);
     if (!game) ctx.throw(404, 'Game ' + gameName + ' not found');
 
-    const gameID = await CreateGame({
+    const gameID = await CreateMatch({
       db,
       game,
       numPlayers,
@@ -263,7 +263,7 @@ export const createRouter = ({
     }
 
     const game = games.find(g => g.name === gameName);
-    const nextRoomID = await CreateGame({
+    const nextRoomID = await CreateMatch({
       db,
       game,
       numPlayers,

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -155,9 +155,9 @@ export const createRouter = ({
    */
   router.get('/games/:name', async ctx => {
     const gameName = ctx.params.name;
-    const gameList = await db.listGames({ gameName });
+    const matchList = await db.listGames({ gameName });
     let matches = [];
-    for (let matchID of gameList) {
+    for (let matchID of matchList) {
       const { metadata } = await (db as StorageAPI.Async).fetch(matchID, {
         metadata: true,
       });

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -135,17 +135,17 @@ export const createRouter = ({
   router.get('/games/:name', async ctx => {
     const gameName = ctx.params.name;
     const gameList = await db.listGames({ gameName });
-    let rooms = [];
+    let matches = [];
     for (let gameID of gameList) {
       const { metadata } = await (db as StorageAPI.Async).fetch(gameID, {
         metadata: true,
       });
       if (!metadata.unlisted) {
-        rooms.push(createClientMatchMetadata(gameID, metadata));
+        matches.push(createClientMatchMetadata(gameID, metadata));
       }
     }
     ctx.body = {
-      rooms: rooms,
+      matches,
     };
   });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -315,14 +315,14 @@ export const createRouter = ({
       ctx.throw(403, 'Invalid credentials ' + credentials);
     }
 
-    // Check if nextRoom is already set, if so, return that id.
-    if (metadata.nextRoomID) {
-      ctx.body = { nextRoomID: metadata.nextRoomID };
+    // Check if nextMatch is already set, if so, return that id.
+    if (metadata.nextMatchID) {
+      ctx.body = { nextMatchID: metadata.nextMatchID };
       return;
     }
 
     const game = games.find(g => g.name === gameName);
-    const nextRoomID = await CreateMatch({
+    const nextMatchID = await CreateMatch({
       db,
       game,
       numPlayers,
@@ -330,12 +330,12 @@ export const createRouter = ({
       uuid,
       unlisted,
     });
-    metadata.nextRoomID = nextRoomID;
+    metadata.nextMatchID = nextMatchID;
 
     await db.setMetadata(matchID, metadata);
 
     ctx.body = {
-      nextRoomID,
+      nextMatchID,
     };
   });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -183,7 +183,7 @@ export const createRouter = ({
       metadata: true,
     });
     if (!metadata) {
-      ctx.throw(404, 'Room ' + matchID + ' not found');
+      ctx.throw(404, 'Match ' + matchID + ' not found');
     }
     ctx.body = createClientMatchMetadata(matchID, metadata);
   });
@@ -213,7 +213,7 @@ export const createRouter = ({
       metadata: true,
     });
     if (!metadata) {
-      ctx.throw(404, 'Game ' + matchID + ' not found');
+      ctx.throw(404, 'Match ' + matchID + ' not found');
     }
     if (!metadata.players[playerID]) {
       ctx.throw(404, 'Player ' + playerID + ' not found');
@@ -257,7 +257,7 @@ export const createRouter = ({
     }
 
     if (!metadata) {
-      ctx.throw(404, 'Game ' + matchID + ' not found');
+      ctx.throw(404, 'Match ' + matchID + ' not found');
     }
     if (!metadata.players[playerID]) {
       ctx.throw(404, 'Player ' + playerID + ' not found');
@@ -306,7 +306,7 @@ export const createRouter = ({
     }
 
     if (!metadata) {
-      ctx.throw(404, 'Game ' + matchID + ' not found');
+      ctx.throw(404, 'Match ' + matchID + ' not found');
     }
     if (!metadata.players[playerID]) {
       ctx.throw(404, 'Player ' + playerID + ' not found');
@@ -358,7 +358,7 @@ export const createRouter = ({
       ctx.throw(403, `newName must be a string, got ${typeof newName}`);
     }
     if (!metadata) {
-      ctx.throw(404, 'Game ' + matchID + ' not found');
+      ctx.throw(404, 'Match ' + matchID + ' not found');
     }
     if (!metadata.players[playerID]) {
       ctx.throw(404, 'Player ' + playerID + ' not found');

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -65,19 +65,17 @@ export const CreateGame = async ({
 /**
  * Create a metadata object without secret credentials to return to the client.
  *
- * @param {string} gameID - The identifier of the game the metadata belongs to.
+ * @param {string} matchID - The identifier of the game the metadata belongs to.
  * @param {object} metadata - The game metadata object to strip credentials from.
  * @return - A metadata object without player credentials.
  */
 const createClientMatchMetadata = (
-  gameID: string,
+  matchID: string,
   metadata: Server.MatchMetadata
 ) => {
   return {
     ...metadata,
-    gameID,
-    roomID: gameID,
-    matchID: gameID,
+    matchID,
     players: Object.values(metadata.players).map(player => {
       // strip away credentials
       const { credentials, ...strippedInfo } = player;

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -44,7 +44,7 @@ export const CreateGame = async ({
 }) => {
   if (!numPlayers || typeof numPlayers !== 'number') numPlayers = 2;
 
-  const metadata: Server.GameMetadata = {
+  const metadata: Server.MatchMetadata = {
     gameName: game.name,
     unlisted: !!unlisted,
     players: {},
@@ -69,9 +69,9 @@ export const CreateGame = async ({
  * @param {object} metadata - The game metadata object to strip credentials from.
  * @return - A metadata object without player credentials.
  */
-const createClientGameMetadata = (
+const createClientMatchMetadata = (
   gameID: string,
-  metadata: Server.GameMetadata
+  metadata: Server.MatchMetadata
 ) => {
   return {
     ...metadata,
@@ -141,7 +141,7 @@ export const createRouter = ({
         metadata: true,
       });
       if (!metadata.unlisted) {
-        rooms.push(createClientGameMetadata(gameID, metadata));
+        rooms.push(createClientMatchMetadata(gameID, metadata));
       }
     }
     ctx.body = {
@@ -157,7 +157,7 @@ export const createRouter = ({
     if (!metadata) {
       ctx.throw(404, 'Room ' + gameID + ' not found');
     }
-    ctx.body = createClientGameMetadata(gameID, metadata);
+    ctx.body = createClientMatchMetadata(gameID, metadata);
   });
 
   router.post('/games/:name/:id/join', koaBody(), async ctx => {

--- a/src/server/db/base.ts
+++ b/src/server/db/base.ts
@@ -69,7 +69,7 @@ export abstract class Async {
    * a game is created.  For example, it might stow away the
    * initial game state in a separate field for easier retrieval.
    */
-  abstract createGame(gameID: string, opts: CreateGameOpts): Promise<void>;
+  abstract createGame(matchID: string, opts: CreateGameOpts): Promise<void>;
 
   /**
    * Update the game state.
@@ -78,7 +78,7 @@ export abstract class Async {
    * existing log for this game.
    */
   abstract setState(
-    gameID: string,
+    matchID: string,
     state: State,
     deltalog?: LogEntry[]
   ): Promise<void>;
@@ -87,7 +87,7 @@ export abstract class Async {
    * Update the game metadata.
    */
   abstract setMetadata(
-    gameID: string,
+    matchID: string,
     metadata: Server.MatchMetadata
   ): Promise<void>;
 
@@ -95,14 +95,14 @@ export abstract class Async {
    * Fetch the game state.
    */
   abstract fetch<O extends FetchOpts>(
-    gameID: string,
+    matchID: string,
     opts: O
   ): Promise<FetchResult<O>>;
 
   /**
    * Remove the game state.
    */
-  abstract wipe(gameID: string): Promise<void>;
+  abstract wipe(matchID: string): Promise<void>;
 
   /**
    * Return all games.
@@ -133,7 +133,7 @@ export abstract class Sync {
    * a game is created.  For example, it might stow away the
    * initial game state in a separate field for easier retrieval.
    */
-  abstract createGame(gameID: string, opts: CreateGameOpts): void;
+  abstract createGame(matchID: string, opts: CreateGameOpts): void;
 
   /**
    * Update the game state.
@@ -141,22 +141,22 @@ export abstract class Sync {
    * If passed a deltalog array, setState should append its contents to the
    * existing log for this game.
    */
-  abstract setState(gameID: string, state: State, deltalog?: LogEntry[]): void;
+  abstract setState(matchID: string, state: State, deltalog?: LogEntry[]): void;
 
   /**
    * Update the match metadata.
    */
-  abstract setMetadata(gameID: string, metadata: Server.MatchMetadata): void;
+  abstract setMetadata(matchID: string, metadata: Server.MatchMetadata): void;
 
   /**
    * Fetch the game state.
    */
-  abstract fetch<O extends FetchOpts>(gameID: string, opts: O): FetchResult<O>;
+  abstract fetch<O extends FetchOpts>(matchID: string, opts: O): FetchResult<O>;
 
   /**
    * Remove the game state.
    */
-  abstract wipe(gameID: string): void;
+  abstract wipe(matchID: string): void;
 
   /**
    * Return all games.

--- a/src/server/db/base.ts
+++ b/src/server/db/base.ts
@@ -22,7 +22,7 @@ export interface FetchOpts {
 export interface FetchFields {
   state: State;
   log: LogEntry[];
-  metadata: Server.GameMetadata;
+  metadata: Server.MatchMetadata;
   initialState: State;
 }
 
@@ -43,7 +43,7 @@ export interface ListGamesOpts {
  */
 export interface CreateGameOpts {
   initialState: State;
-  metadata: Server.GameMetadata;
+  metadata: Server.MatchMetadata;
 }
 
 export abstract class Async {
@@ -88,7 +88,7 @@ export abstract class Async {
    */
   abstract setMetadata(
     gameID: string,
-    metadata: Server.GameMetadata
+    metadata: Server.MatchMetadata
   ): Promise<void>;
 
   /**
@@ -146,7 +146,7 @@ export abstract class Sync {
   /**
    * Update the game metadata.
    */
-  abstract setMetadata(gameID: string, metadata: Server.GameMetadata): void;
+  abstract setMetadata(gameID: string, metadata: Server.MatchMetadata): void;
 
   /**
    * Fetch the game state.

--- a/src/server/db/base.ts
+++ b/src/server/db/base.ts
@@ -144,7 +144,7 @@ export abstract class Sync {
   abstract setState(gameID: string, state: State, deltalog?: LogEntry[]): void;
 
   /**
-   * Update the game metadata.
+   * Update the match metadata.
    */
   abstract setMetadata(gameID: string, metadata: Server.MatchMetadata): void;
 

--- a/src/server/db/flatfile.test.ts
+++ b/src/server/db/flatfile.test.ts
@@ -32,7 +32,7 @@ describe('FlatFile', () => {
 
     await db.createGame('gameID', {
       initialState: state as State,
-      metadata: metadata as Server.GameMetadata,
+      metadata: metadata as Server.MatchMetadata,
     });
 
     // Must return created game.

--- a/src/server/db/flatfile.ts
+++ b/src/server/db/flatfile.ts
@@ -16,7 +16,7 @@ export class FlatFile extends StorageAPI.Async {
   private games: {
     init: (opts: object) => Promise<void>;
     setItem: (id: string, value: any) => Promise<any>;
-    getItem: (id: string) => Promise<State | Server.GameMetadata | LogEntry[]>;
+    getItem: (id: string) => Promise<State | Server.MatchMetadata | LogEntry[]>;
     removeItem: (id: string) => Promise<void>;
     clear: () => {};
     keys: () => Promise<string[]>;
@@ -88,7 +88,7 @@ export class FlatFile extends StorageAPI.Async {
       const key = MetadataKey(gameID);
       result.metadata = (await this.request(() =>
         this.games.getItem(key)
-      )) as Server.GameMetadata;
+      )) as Server.MatchMetadata;
     }
 
     if (opts.log) {
@@ -125,7 +125,7 @@ export class FlatFile extends StorageAPI.Async {
     return await this.request(() => this.games.setItem(id, state));
   }
 
-  async setMetadata(id: string, metadata: Server.GameMetadata): Promise<void> {
+  async setMetadata(id: string, metadata: Server.MatchMetadata): Promise<void> {
     const key = MetadataKey(id);
 
     return await this.request(() => this.games.setItem(key, metadata));

--- a/src/server/db/inmemory.test.ts
+++ b/src/server/db/inmemory.test.ts
@@ -30,7 +30,7 @@ describe('InMemory', () => {
     db.createGame('gameID', {
       metadata: {
         gameName: 'tic-tac-toe',
-      } as Server.GameMetadata,
+      } as Server.MatchMetadata,
       initialState: stateEntry as State,
     });
 

--- a/src/server/db/inmemory.ts
+++ b/src/server/db/inmemory.ts
@@ -15,7 +15,7 @@ import * as StorageAPI from './base';
 export class InMemory extends StorageAPI.Sync {
   private state: Map<string, State>;
   private initial: Map<string, State>;
-  private metadata: Map<string, Server.GameMetadata>;
+  private metadata: Map<string, Server.MatchMetadata>;
   private log: Map<string, LogEntry[]>;
 
   /**
@@ -41,7 +41,7 @@ export class InMemory extends StorageAPI.Sync {
   /**
    * Write the game metadata to the in-memory object.
    */
-  setMetadata(gameID: string, metadata: Server.GameMetadata) {
+  setMetadata(gameID: string, metadata: Server.MatchMetadata) {
     this.metadata.set(gameID, metadata);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,7 +276,7 @@ export namespace Server {
     data?: any;
   };
 
-  export interface GameMetadata {
+  export interface MatchMetadata {
     gameName: string;
     players: { [id: number]: PlayerMetadata };
     setupData?: any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -281,7 +281,7 @@ export namespace Server {
     players: { [id: number]: PlayerMetadata };
     setupData?: any;
     gameover?: any;
-    nextRoomID?: string;
+    nextMatchID?: string;
     unlisted?: boolean;
   }
 }


### PR DESCRIPTION
Here's where I'm at with this work. I've tried to do it slowly, with a lot of small, focused commits, to make this easier to review. I know how painful this type of change is to review, sorry in advance! :)

I believe this covers all of the instances of "room" in the api and lobby, as well as all the cases where "game" was used but it actually meant "match". It is, however, likely that I have missed some instances in some corners of the app. I'm counting on you to spot them! :grin: 

Regarding documentation, I guess we'll want to explain the changes very clearly. Should that be in the changelog? I want to wait until these changes are validated before writing that doc though.