### PR TITLE
Add support for socket.io-adapter implementations

### DIFF
--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -93,14 +93,6 @@ describe('new', () => {
     const server = Server({ games: [game], authenticateCredentials });
     expect(server.db).not.toBeNull();
   });
-
-  test('custom socket.io adapter implementation', () => {
-    const game = {}
-    const socketAdapter = {}
-    const server = Server({ games: [game], socketAdapter })
-
-    expect(server.transport.socketAdapter).toBe(socketAdapter)
-  })
 });
 
 describe('run', () => {

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -50,6 +50,9 @@ jest.mock('koa-socket-2', () => {
     on(type, callback) {
       callback((this as any).socket);
     }
+    adapter(adapter) {
+      return this
+    }
   };
 });
 
@@ -90,6 +93,14 @@ describe('new', () => {
     const server = Server({ games: [game], authenticateCredentials });
     expect(server.db).not.toBeNull();
   });
+
+  test('custom socket.io adapter implementation', () => {
+    const game = {}
+    const socketAdapter = {}
+    const server = Server({ games: [game], socketAdapter })
+
+    expect(server.transport.socketAdapter).toBe(socketAdapter)
+  })
 });
 
 describe('run', () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -65,7 +65,6 @@ interface ServerOpts {
   authenticateCredentials?: ServerTypes.AuthenticateCredentials;
   generateCredentials?: ServerTypes.GenerateCredentials;
   https?: HttpsOptions;
-  socketAdapter?;
 }
 
 /**
@@ -85,7 +84,6 @@ export function Server({
   authenticateCredentials,
   generateCredentials,
   https,
-  socketAdapter,
 }: ServerOpts) {
   const app = new Koa();
 
@@ -104,7 +102,6 @@ export function Server({
     transport = new SocketIO({
       auth,
       https,
-      socketAdapter,
     });
   }
   transport.init(app, games);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -65,6 +65,7 @@ interface ServerOpts {
   authenticateCredentials?: ServerTypes.AuthenticateCredentials;
   generateCredentials?: ServerTypes.GenerateCredentials;
   https?: HttpsOptions;
+  socketAdapter?;
 }
 
 /**
@@ -84,6 +85,7 @@ export function Server({
   authenticateCredentials,
   generateCredentials,
   https,
+  socketAdapter,
 }: ServerOpts) {
   const app = new Koa();
 
@@ -102,6 +104,7 @@ export function Server({
     transport = new SocketIO({
       auth,
       https,
+      socketAdapter,
     });
   }
   transport.init(app, games);
@@ -109,6 +112,7 @@ export function Server({
   return {
     app,
     db,
+    transport,
 
     run: async (portOrConfig: number | object, callback?: () => void) => {
       const serverRunConfig = createServerRunConfig(portOrConfig, callback);

--- a/src/server/transport/socketio.test.ts
+++ b/src/server/transport/socketio.test.ts
@@ -75,9 +75,14 @@ jest.mock('koa-socket-2', () => {
 
   class MockIO {
     socket: MockSocket;
+    socketAdapter: any;
 
     constructor() {
       this.socket = new MockSocket();
+    }
+
+    adapter(socketAdapter) {
+      this.socketAdapter = socketAdapter;
     }
 
     attach(app) {
@@ -113,6 +118,22 @@ describe('basic', () => {
     expect(app.context.io).toBeDefined();
   });
 });
+
+describe('socketAdapter', () => {
+  const app: any = { context: {} };
+  const games = [ProcessGameConfig({ seed: 0 })];
+
+  let socketAdapter = jest.fn();
+
+  beforeEach(() => {
+    const transport = new SocketIOTestAdapter({ socketAdapter });
+    transport.init(app, games);
+  });
+
+  test('socketAdapter is passed', () => {
+    expect(app.io.socketAdapter).toBe(socketAdapter)
+  })
+})
 
 describe('TransportAPI', () => {
   let io;

--- a/src/server/transport/socketio.ts
+++ b/src/server/transport/socketio.ts
@@ -64,6 +64,7 @@ export interface SocketOpts {
   auth?: boolean | AuthFn;
   https?: HttpsOptions;
   socketOpts?: SocketOptions;
+  socketAdapter?: any;
 }
 
 /**
@@ -74,13 +75,15 @@ export class SocketIO {
   protected roomInfo: Map<any, any>;
   private auth: boolean | AuthFn;
   private https: HttpsOptions;
+  private socketAdapter: any;
   private socketOpts: SocketOptions;
 
-  constructor({ auth = true, https, socketOpts }: SocketOpts = {}) {
+  constructor({ auth = true, https, socketAdapter, socketOpts }: SocketOpts = {}) {
     this.clientInfo = new Map();
     this.roomInfo = new Map();
     this.auth = auth;
     this.https = https;
+    this.socketAdapter = socketAdapter;
     this.socketOpts = socketOpts;
   }
 
@@ -95,6 +98,10 @@ export class SocketIO {
 
     app.context.io = io;
     io.attach(app, !!this.https, this.https);
+
+    if (this.socketAdapter) {
+      io.adapter(this.socketAdapter);
+    }
 
     for (const game of games) {
       const nsp = app._io.of(game.name);


### PR DESCRIPTION
Allows using socket adapter, that's one possible solution for horizontal scaling issues.

The issue where this is requested: https://github.com/nicolodavis/boardgame.io/issues/534

More information about socket.io-adapter option: https://socket.io/docs/server-api/#server-adapter-value
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
