### PR TITLE
feat(lobby): playAgain endpoint uses previous game config as defaults

### DIFF
--- a/docs/documentation/api/Lobby.md
+++ b/docs/documentation/api/Lobby.md
@@ -154,4 +154,8 @@ Accepts these parameters:
 
 `credentials` (required): player's credentials.
 
+`numPlayers` (optional): the number of players. Defaults to the `numPlayers` value of the previous room.
+
+`setupData` (optional): custom object that was passed to the game `setup` function. Defaults to the `setupData` object of the previous room.
+
 Returns `nextRoomID`, which is the ID of the newly created room that the user should go to play again.

--- a/src/server/api.test.ts
+++ b/src/server/api.test.ts
@@ -1010,6 +1010,12 @@ describe('.createApiServer', () => {
         fetch: async () => {
           return {
             metadata: {
+              setupData: {
+                colors: {
+                  '0': 'green',
+                  '1': 'red',
+                },
+              },
               players: {
                 '0': {
                   name: 'alice',
@@ -1018,6 +1024,10 @@ describe('.createApiServer', () => {
                 '1': {
                   name: 'bob',
                   credentials: 'SECRET2',
+                },
+                '2': {
+                  name: 'chris',
+                  credentials: 'SECRET3',
                 },
               },
             },
@@ -1031,15 +1041,61 @@ describe('.createApiServer', () => {
         uuid: () => 'newGameID',
       };
       const app = createApiServer({ db, games, lobbyConfig });
+
       response = await request(app.callback())
         .post('/games/foo/1/playAgain')
-        .send('playerID=0&credentials=SECRET1&numPlayers=4');
+        .send({
+          playerID: 0,
+          credentials: 'SECRET1',
+          numPlayers: 4,
+          setupData: {
+            colors: {
+              '3': 'blue',
+            },
+          },
+        });
       expect(db.mocks.createGame).toHaveBeenCalledWith(
         'newGameID',
         expect.objectContaining({
           initialState: expect.objectContaining({
             ctx: expect.objectContaining({
               numPlayers: 4,
+            }),
+          }),
+          metadata: expect.objectContaining({
+            setupData: expect.objectContaining({
+              colors: expect.objectContaining({
+                '3': 'blue',
+              }),
+            }),
+          }),
+        })
+      );
+      expect(response.body.nextRoomID).toBe('newGameID');
+    });
+
+    test('when game configuration not supplied, uses previous game config', async () => {
+      const lobbyConfig = {
+        uuid: () => 'newGameID',
+      };
+      const app = createApiServer({ db, games, lobbyConfig });
+      response = await request(app.callback())
+        .post('/games/foo/1/playAgain')
+        .send('playerID=0&credentials=SECRET1');
+      expect(db.mocks.createGame).toHaveBeenCalledWith(
+        'newGameID',
+        expect.objectContaining({
+          initialState: expect.objectContaining({
+            ctx: expect.objectContaining({
+              numPlayers: 3,
+            }),
+          }),
+          metadata: expect.objectContaining({
+            setupData: expect.objectContaining({
+              colors: expect.objectContaining({
+                '0': 'green',
+                '1': 'red',
+              }),
             }),
           }),
         })
@@ -1085,7 +1141,7 @@ describe('.createApiServer', () => {
       expect(response.status).toEqual(404);
     });
 
-    test('when the playerID is undefnied throws error 403', async () => {
+    test('when the playerID is undefined throws error 403', async () => {
       const app = createApiServer({ db, games });
       response = await request(app.callback())
         .post('/games/foo/1/playAgain')
@@ -1097,7 +1153,7 @@ describe('.createApiServer', () => {
       const app = createApiServer({ db, games });
       response = await request(app.callback())
         .post('/games/foo/1/playAgain')
-        .send('playerID=2&credentials=SECRET1');
+        .send('playerID=3&credentials=SECRET1');
       expect(response.status).toEqual(404);
     });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -245,10 +245,6 @@ export const addApiToServer = ({
     const { metadata } = await (db as StorageAPI.Async).fetch(gameID, {
       metadata: true,
     });
-    // User-data to pass to the game setup function.
-    const setupData = ctx.request.body.setupData;
-    // The number of players for this game instance.
-    let numPlayers = parseInt(ctx.request.body.numPlayers);
 
     if (typeof playerID === 'undefined' || playerID === null) {
       ctx.throw(403, 'playerID is required');
@@ -269,6 +265,13 @@ export const addApiToServer = ({
       ctx.body = { nextRoomID: metadata.nextRoomID };
       return;
     }
+
+    // User-data to pass to the game setup function.
+    const setupData = ctx.request.body.setupData || metadata.setupData;
+    // The number of players for this game instance.
+    const numPlayers =
+      parseInt(ctx.request.body.numPlayers) ||
+      Object.keys(metadata.players).length;
 
     const game = games.find(g => g.name === gameName);
     const nextRoomID = await CreateGame(


### PR DESCRIPTION
#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).

From https://github.com/nicolodavis/boardgame.io/issues/718

When hitting the lobby/playAgain API, uses `setupData` and `numPlayers` values from the specified previous game unless they are explicitly overridden. 

Update docs to reflect this.