### PR TITLE
refactor(ai): Convert to Typescript

### DIFF
--- a/src/ai/random-bot.ts
+++ b/src/ai/random-bot.ts
@@ -7,12 +7,13 @@
  */
 
 import { Bot } from './bot';
+import { Ctx, PlayerID } from '../types';
 
 /**
  * Bot that picks a move at random.
  */
 export class RandomBot extends Bot {
-  play({ G, ctx }, playerID) {
+  play({ G, ctx }: { G: any; ctx: Ctx }, playerID: PlayerID) {
     const moves = this.enumerate(G, ctx, playerID);
     return Promise.resolve({ action: this.random(moves) });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,7 +249,16 @@ export interface Game<G extends any = any, CtxWithPlugins extends Ctx = Ctx> {
   playerView?: (G: G, ctx: CtxWithPlugins, playerID: PlayerID) => any;
   plugins?: Array<Plugin<any, any, G>>;
   ai?: {
-    enumerate: (G: G, ctx: Ctx) => { move: string; args: any[] }[];
+    enumerate: (
+      G: G,
+      ctx: Ctx,
+      playerID: PlayerID
+    ) => Array<
+      | { event: string; args?: any[] }
+      | { move: string; args?: any[] }
+      | ActionShape.MakeMove
+      | ActionShape.GameEvent
+    >;
   };
   processMove?: (
     state: State<G, Ctx | CtxWithPlugins>,


### PR DESCRIPTION
This is a straight conversion of the AI code to Typescript.

- The key detail is that now the base `Bot` class is declared as an abstract class, specifying the expected signature of the `play` method extending bots should implement. I’ve marked all class fields & methods as private or protected wherever possible.

- Improved the `ai.enumerate` type in the Game definition.

- Fix: `bot.random()` will now return `undefined` if passed an empty array (instead of `Math.floor(number * [])`)

- Fix: `objectives` is consistently called with `playerID` in the MCTS bot