### PR TITLE
Remove --save option from npm install occurrences

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ networking or storage code.
 ### Installation
 
 ```sh
-npm install --save boardgame.io
+npm install boardgame.io
 ```
 
 ### Documentation

--- a/docs/documentation/deployment.md
+++ b/docs/documentation/deployment.md
@@ -18,7 +18,7 @@ Below is an example of how to achieve that.
 First install these extra dependencies: 
 
 ```
-npm i --save koa-static
+npm i koa-static
 ```
 Then adjust your `server.js` file like this:
 

--- a/docs/documentation/multiplayer.md
+++ b/docs/documentation/multiplayer.md
@@ -210,7 +210,7 @@ Because `Game.js` is an ES module, we will use [esm](https://github.com/standard
 which enables us to use `import` statements in a Node environment:
 
 ```
-npm install --save esm
+npm install esm
 ```
 
 We can then add a new script to our `package.json` to simplify

--- a/docs/documentation/storage.md
+++ b/docs/documentation/storage.md
@@ -12,7 +12,7 @@ for a custom backend.
 First, install the necessary packages:
 
 ```
-npm install --save node-persist
+npm install node-persist
 ```
 
 Then modify your server spec to indicate that you want to connect to a flatfile database:

--- a/docs/documentation/tutorial.md
+++ b/docs/documentation/tutorial.md
@@ -31,7 +31,7 @@ npm init
 We’re going to add boardgame.io and also Parcel to help us build our app:
 
 ```
-npm install --save boardgame.io
+npm install boardgame.io
 npm install --save-dev parcel-bundler
 ```
 
@@ -86,7 +86,7 @@ command line tool to initialize our React app and then add boardgame.io to it.
 ```
 npx create-react-app bgio-tutorial
 cd bgio-tutorial
-npm install --save boardgame.io
+npm install boardgame.io
 ```
 
 While we’re here, let’s also create an empty JavaScript file for our game code:

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,7 @@
       <h2>Installation</h2>
 
       <code>
-      npm install --save boardgame.io
+      npm install boardgame.io
       </code>
 
       <h2>License</h2>


### PR DESCRIPTION
npm install executes "--save" by default since npm v5.0.0.

Links:
https://github.com/npm/npm/releases/tag/v5.0.0
https://blog.npmjs.org/post/161081169345/v500

> npm will --save by default now. Additionally, package-lock.json
> will be automatically created unless an npm-shrinkwrap.json exists.

I've left out `integration/README.md` and `node_modules/`.

#### Checklist

* [x] Use a separate branch in your local repo (not `master`).
* [x] Test coverage is 100% (or you have a story for why it's ok).
