### PR TITLE
allow to filter listGames query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9539,6 +9539,12 @@
         "realpath-native": "^1.1.0"
       }
     },
+    "jest-date-mock": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/jest-date-mock/-/jest-date-mock-1.0.8.tgz",
+      "integrity": "sha512-0Lyp+z9xvuNmLbK+5N6FOhSiBeux05Lp5bbveFBmYo40Aggl2wwxFoIrZ+rOWC8nDNcLeBoDd2miQdEDSf3iQw==",
+      "dev": true
+    },
     "jest-diff": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "husky": "^1.3.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.0.0",
+    "jest-date-mock": "^1.0.8",
     "jest-transform-svelte": "^2.1.0",
     "lint-staged": "^8.1.0",
     "node-persist": "^3.0.4",
@@ -174,7 +175,8 @@
       "src/types.ts"
     ],
     "setupFiles": [
-      "raf/polyfill"
+      "raf/polyfill",
+      "jest-date-mock"
     ],
     "setupFilesAfterEnv": [
       "@testing-library/jest-dom/extend-expect"

--- a/src/master/master.ts
+++ b/src/master/master.ts
@@ -306,15 +306,14 @@ export class Master {
     const { deltalog, ...stateWithoutDeltalog } = state;
 
     let newMetadata: Server.MatchMetadata | undefined;
-    if (
-      metadata &&
-      !('gameover' in metadata) &&
-      state.ctx.gameover !== undefined
-    ) {
+    if (metadata && !('gameover' in metadata)) {
       newMetadata = {
         ...metadata,
-        gameover: state.ctx.gameover,
+        updatedAt: Date.now(),
       };
+      if (state.ctx.gameover !== undefined) {
+        newMetadata.gameover = state.ctx.gameover;
+      }
     }
 
     if (IsSynchronous(this.storageAPI)) {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -48,6 +48,8 @@ export const CreateMatch = async ({
     gameName: game.name,
     unlisted: !!unlisted,
     players: {},
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
   };
   if (setupData !== undefined) metadata.setupData = setupData;
   for (let playerIndex = 0; playerIndex < numPlayers; playerIndex++) {
@@ -155,7 +157,40 @@ export const createRouter = ({
    */
   router.get('/games/:name', async ctx => {
     const gameName = ctx.params.name;
-    const matchList = await db.listGames({ gameName });
+    const {
+      isGameover: isGameoverString,
+      updatedBefore: updatedBeforeString,
+      updatedAfter: updatedAfterString,
+    } = ctx.query;
+
+    let isGameover: boolean | undefined;
+    if (isGameoverString === 'true') {
+      isGameover = true;
+    } else if (isGameoverString === 'false') {
+      isGameover = false;
+    }
+    let updatedBefore: number | undefined;
+    if (updatedBeforeString) {
+      const parsedNumber = Number.parseInt(updatedBeforeString, 10);
+      if (parsedNumber > 0) {
+        updatedBefore = parsedNumber;
+      }
+    }
+    let updatedAfter: number | undefined;
+    if (updatedAfterString) {
+      const parsedNumber = Number.parseInt(updatedAfterString, 10);
+      if (parsedNumber > 0) {
+        updatedAfter = parsedNumber;
+      }
+    }
+    const matchList = await db.listGames({
+      gameName,
+      where: {
+        isGameover,
+        updatedAfter,
+        updatedBefore,
+      },
+    });
     let matches = [];
     for (let matchID of matchList) {
       const { metadata } = await (db as StorageAPI.Async).fetch(matchID, {

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -164,10 +164,12 @@ export const createRouter = ({
     } = ctx.query;
 
     let isGameover: boolean | undefined;
-    if (isGameoverString === 'true') {
-      isGameover = true;
-    } else if (isGameoverString === 'false') {
-      isGameover = false;
+    if (isGameoverString) {
+      if (isGameoverString.toLowerCase() === 'true') {
+        isGameover = true;
+      } else if (isGameoverString.toLowerCase() === 'false') {
+        isGameover = false;
+      }
     }
     let updatedBefore: number | undefined;
     if (updatedBeforeString) {

--- a/src/server/db/base.ts
+++ b/src/server/db/base.ts
@@ -36,6 +36,11 @@ export type FetchResult<O extends FetchOpts> = Object.Pick<
 
 export interface ListGamesOpts {
   gameName?: string;
+  where?: {
+    isGameover?: boolean;
+    updatedBefore?: number;
+    updatedAfter?: number;
+  };
 }
 
 /**

--- a/src/server/db/inmemory.test.ts
+++ b/src/server/db/inmemory.test.ts
@@ -30,6 +30,7 @@ describe('InMemory', () => {
     db.createGame('gameID', {
       metadata: {
         gameName: 'tic-tac-toe',
+        updatedAt: new Date(2020, 1).getTime(),
       } as Server.MatchMetadata,
       initialState: stateEntry as State,
     });
@@ -43,13 +44,93 @@ describe('InMemory', () => {
     expect(initialState).toEqual(stateEntry);
   });
 
-  test('listGames', () => {
-    let keys = db.listGames({});
-    expect(keys).toEqual(['gameID']);
-    keys = db.listGames({ gameName: 'tic-tac-toe' });
-    expect(keys).toEqual(['gameID']);
-    keys = db.listGames({ gameName: 'chess' });
-    expect(keys).toEqual([]);
+  describe('listGames', () => {
+    test('filter by gameName', () => {
+      let keys = db.listGames({});
+      expect(keys).toEqual(['gameID']);
+      keys = db.listGames({ gameName: 'tic-tac-toe' });
+      expect(keys).toEqual(['gameID']);
+      keys = db.listGames({ gameName: 'chess' });
+      expect(keys).toEqual([]);
+    });
+
+    test('filter by isGameover', () => {
+      const stateEntry: unknown = { a: 1 };
+      db.createGame('gameID2', {
+        metadata: {
+          gameName: 'tic-tac-toe',
+          gameover: 'gameover',
+          updatedAt: new Date(2020, 3).getTime(),
+        } as Server.MatchMetadata,
+        initialState: stateEntry as State,
+      });
+
+      let keys = db.listGames({});
+      expect(keys).toEqual(['gameID', 'gameID2']);
+      keys = db.listGames({ where: { isGameover: true } });
+      expect(keys).toEqual(['gameID2']);
+      keys = db.listGames({ where: { isGameover: false } });
+      expect(keys).toEqual(['gameID']);
+    });
+
+    test('filter by updatedBefore', () => {
+      const stateEntry: unknown = { a: 1 };
+      db.createGame('gameID3', {
+        metadata: {
+          gameName: 'tic-tac-toe',
+          updatedAt: new Date(2020, 5).getTime(),
+        } as Server.MatchMetadata,
+        initialState: stateEntry as State,
+      });
+      const timestamp = new Date(2020, 4);
+
+      let keys = db.listGames({});
+      expect(keys).toEqual(['gameID', 'gameID2', 'gameID3']);
+      keys = db.listGames({ where: { updatedBefore: timestamp.getTime() } });
+      expect(keys).toEqual(['gameID', 'gameID2']);
+    });
+
+    test('filter by updatedAfter', () => {
+      const timestamp = new Date(2020, 4);
+
+      let keys = db.listGames({});
+      expect(keys).toEqual(['gameID', 'gameID2', 'gameID3']);
+      keys = db.listGames({ where: { updatedAfter: timestamp.getTime() } });
+      expect(keys).toEqual(['gameID3']);
+    });
+
+    test('filter combined', () => {
+      const timestamp = new Date(2020, 4);
+      const timestamp2 = new Date(2020, 2, 15);
+      let keys = db.listGames({
+        gameName: 'chess',
+        where: { isGameover: true },
+      });
+      expect(keys).toEqual([]);
+      keys = db.listGames({
+        where: { isGameover: true, updatedBefore: timestamp.getTime() },
+      });
+      expect(keys).toEqual(['gameID2']);
+      keys = db.listGames({
+        where: { isGameover: false, updatedBefore: timestamp.getTime() },
+      });
+      expect(keys).toEqual(['gameID']);
+      keys = db.listGames({
+        where: { isGameover: true, updatedAfter: timestamp.getTime() },
+      });
+      expect(keys).toEqual([]);
+      keys = db.listGames({
+        where: { isGameover: false, updatedAfter: timestamp.getTime() },
+      });
+      expect(keys).toEqual(['gameID3']);
+      keys = db.listGames({
+        where: {
+          updatedBefore: timestamp.getTime(),
+          updatedAfter: timestamp2.getTime(),
+        },
+      });
+      expect(keys).toEqual(['gameID2']);
+    });
   });
 
   test('remove', () => {

--- a/src/server/db/inmemory.ts
+++ b/src/server/db/inmemory.ts
@@ -96,15 +96,44 @@ export class InMemory extends StorageAPI.Sync {
    * Return all keys.
    */
   listGames(opts?: StorageAPI.ListGamesOpts): string[] {
-    if (opts && opts.gameName !== undefined) {
-      let gameIDs = [];
-      this.metadata.forEach((metadata, gameID) => {
-        if (metadata.gameName === opts.gameName) {
-          gameIDs.push(gameID);
+    return [...this.metadata.entries()]
+      .filter(([key, metadata]) => {
+        if (!opts) {
+          return true;
         }
-      });
-      return gameIDs;
-    }
-    return [...this.metadata.keys()];
+
+        if (
+          opts.gameName !== undefined &&
+          metadata.gameName !== opts.gameName
+        ) {
+          return false;
+        }
+
+        if (opts.where !== undefined) {
+          if (opts.where.isGameover !== undefined) {
+            const isGameover = metadata.gameover !== undefined;
+            if (isGameover !== opts.where.isGameover) {
+              return false;
+            }
+          }
+
+          if (
+            opts.where.updatedBefore !== undefined &&
+            metadata.updatedAt >= opts.where.updatedBefore
+          ) {
+            return false;
+          }
+
+          if (
+            opts.where.updatedAfter !== undefined &&
+            metadata.updatedAt <= opts.where.updatedAfter
+          ) {
+            return false;
+          }
+        }
+
+        return true;
+      })
+      .map(([key]) => key);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -288,6 +288,8 @@ export namespace Server {
     gameover?: any;
     nextMatchID?: string;
     unlisted?: boolean;
+    createdAt: number;
+    updatedAt: number;
   }
 }
 


### PR DESCRIPTION
This PR ( based on issue #735 ) adds `createdAt` and `updatedAt` fields to the metadata containing numeric timestamps. Furthermore, the following query parameters were given to the listGames endpoint: `isGameover`, `updatedBefore`, `updatedAfter`.

#### remaining tasks

* [x] implement filter in the included storage adapters
